### PR TITLE
Generalized environment obj and parameter format

### DIFF
--- a/autoprotocol/environment.py
+++ b/autoprotocol/environment.py
@@ -1,0 +1,18 @@
+
+
+class Environment(object):
+
+	def __init__(self, 
+					protocol = None, 
+					samples = [], 
+					params = {},
+					container_pool = [],
+					resourcedb = None):
+
+		# The Transcriptic protocol object to which to append commands
+		self.protocol = protocol
+		self.samples = samples
+		self.params = params
+		self.container_pool = container_pool
+		self.resourcedb = resourcedb
+

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -49,6 +49,9 @@ def run(fn):
     protocol = Protocol()
     params = protocol._ref_containers_and_wells(config["parameters"])
 
-    fn(protocol, params)
+    from autoprotocol.environment import Environment
+    env = Environment(protocol=protocol, params=params)
 
-    print json.dumps(protocol.as_dict(), indent=2)
+    fn(env)
+
+    print json.dumps(env.protocol.as_dict(), indent=2)

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -755,7 +755,7 @@ class Protocol(object):
         for k, v in params.items():
             if isinstance(v, dict):
                 parameters[str(k)] = self._ref_containers_and_wells(v)
-            if isinstance(v, list) and isinstance(v[0], dict):
+            if isinstance(v, list) and isinstance(v[0], dict) and ("id" in v[0]):
                 for cont in v:
                     self._ref_containers_and_wells(cont.encode('utf-8'))
             elif isinstance(v, dict) and "type" in v:
@@ -783,7 +783,7 @@ class Protocol(object):
                     well = w.rsplit("/")[1].encode('utf-8')
                     group.append(self.refs[cont].container.well(well))
                 parameters[str(k)] = group
-            elif "/" in str(v):
+            elif ("/" in str(v)) and (":" not in str(v)):
                 if not v.rsplit("/")[0] in self.refs:
                     raise RuntimeError("Parameters contain well references to \
                         a container that isn't referenced in this protocol.")


### PR DESCRIPTION
Modifications to protocol.py allow solution prototypes/recipes to be
specified as parameters, for example the following:

{
    "parameters":
    {
        "reagent_thaw_time": "10:minute",
        "reagent_thaw_temp": "ambient",
        "initial_temp":"94:celsius",
        "initial_time":"120:second",
        "extension_temp":"72:celsius",
        "extension_time":"90:second",
        "annealing_temp":"55:celsius",
        "annealing_time":"60:second",
        "melting_temp":"94:celsius",
        "melting_time":"45:second",
        "final_step_temp":"72:celsius",
        "final_step_time":"600:second",
        "hold_temp":"8:celsius",
        "hold_time":"600:second",
        "cycles":30,
        "solutions": {"pcr_setup":{
                        "components": [
                                {"name": "primer_f",
                                "role": "component",
                                "db_attributes":
"primer_16s_515_f:database_label",
                                "target_concentration": "0.5:uM"},
                                {"name": "primer_r",
                                "role": "component",
                                "db_attributes":
"primer_16s_806_r:database_label",
                                "target_concentration": "0.5:uM"},
                                {"name": "target_dna",
                                "role": "component",
                                "target_concentration":
"2:ng/microliter"},
                                {"name": "pcr_master_mix",
                                "role": "component",
                                "db_attributes":
"invitrogen_pcr_mix_new:database_label;invitrogen:supplier;11306-016:mod
el",
                                "target_concentration": "1:x"}],
                        "target_voume": "55:microliter"
                        }
                    }
    }
}

Also added fix that assumed any string with a slash was a well
reference, whereas will want to be able to use slashes in
concentrations. “Has / and not :” is still not an appropriately fault
tolerant way to identify something that needs to be ref’d, though…