### PR TITLE
Remove redundant assert

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -138,7 +138,6 @@ class Protocol(object):
 
         """
         assert name not in self.refs
-        assert storage or discard
         opts = {}
         cont_type = self.container_type(cont_type)
         if id:


### PR DESCRIPTION
Omitting both the discard and storage arguments should raise a ValueError as the docs say. The code is in place, but was never reached due to this assert statement. This would also give a meaningless assertion error instead of the nice error message.