### PR TITLE
Fix docs typo: methdods -> methods

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -22,7 +22,7 @@ or, alternatively:
 Building a Protocol
 -------------------
 
-A basic protocol object has empty "refs" and "instructions" stanzas.  Various helper methdods in the Protocol class are then used to append instructions and refs to the object such as in the simple protocol below:
+A basic protocol object has empty "refs" and "instructions" stanzas.  Various helper methods in the Protocol class are then used to append instructions and refs to the object such as in the simple protocol below:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ or, alternatively:
 Building a Protocol
 -------------------
 
-A basic protocol object has empty "refs" and "instructions" stanzas.  Various helper methdods in the Protocol class are then used to append instructions and refs to the object such as in the simple protocol below:
+A basic protocol object has empty "refs" and "instructions" stanzas.  Various helper methods in the Protocol class are then used to append instructions and refs to the object such as in the simple protocol below:
 
 .. code-block:: python
 


### PR DESCRIPTION
Note that I didn't update the files in `docs/_build/`, as AFAIK the online docs get rebuilt from the source.