### PR TITLE
python3 support

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1,4 +1,8 @@
 from .unit import Unit
+import sys
+
+if sys.version_info[0] >= 3:
+    xrange = range
 
 '''
     :copyright: 2015 by The Autoprotocol Development Team, see AUTHORS

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -243,12 +243,13 @@ class Thermocycle(Instruction):
         """
 
         dye_names = reduce(lambda x, y: x.union(y),
-                           [set(v) for v in well_map.itervalues()])
+                           [set(well_map[k]) for k in well_map])
         if Thermocycle.find_invalid_dyes(dye_names):
             raise ValueError("thermocycle instruction supplied the following "
                              "invalid dyes: %s" % ", ".join(Thermocycle.find_invalid_dyes(dye_names)))
         dye_map = {dye: [] for dye in dye_names}
-        for well, dyes in well_map.iteritems():
+        for well in well_map:
+            dyes = well_map[well]
             for dye in dyes:
                 dye_map[dye] += [well]
         return dye_map

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -330,7 +330,10 @@ class Protocol(object):
 
         """
         return {
-            "refs": dict(map(lambda (k, v): (k, v.opts), self.refs.items())),
+            "refs": dict(
+                (k, v.opts)
+                for key, value in self.refs.items()
+            ),
             "instructions": map(lambda x: self._refify(x.data),
                                 self.instructions)
         }
@@ -1991,7 +1994,8 @@ class Protocol(object):
         return "%s/%d" % (self._ref_for_container(well.container), well.index)
 
     def _ref_for_container(self, container):
-        for k, v in self.refs.iteritems():
+        for k in self.refs:
+            v = self.refs[k]
             if v.container is container:
                 return k
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -331,7 +331,7 @@ class Protocol(object):
         """
         return {
             "refs": dict(
-                (k, v.opts)
+                (key, value.opts)
                 for key, value in self.refs.items()
             ),
             "instructions": map(lambda x: self._refify(x.data),

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -47,11 +47,22 @@ class Unit(object):
         else:
             return Unit(self.value - other.value, self.unit)
 
-    def __cmp__(self, other):
+    def _check_type(self, other):
         if not isinstance(other, Unit):
             raise ValueError("Both operands must be of type Unit")
         elif self.unit != other.unit:
             raise ValueError("unit %s is not %s" % (self.unit, other.unit))
+
+    def __lt__(self, other):
+        self._check_type(other)
+        return self.value < other.value
+
+    def __eq__(self, other):
+        self._check_type(other)
+        return self.value == other.value
+
+    def __cmp__(self, other):
+        self._check_type(other)
         return cmp(self.value, other.value)
 
     def __mul__(self, other):


### PR DESCRIPTION
* Removed use of `.iteritems()` and `.itervalues()`, iterate over dictionary's keys and manually grab the values
* Fall back on `str` type from `basestring`
* Define `xrange = range` when running python3
* Define `__eq__` and `__lt__` for python3 comparisons

The unit tests pass when running Python 3.4.2 as well as Python 2.7.5. I found a few places in the code where python2 conventions were still used, but the tests still passing. I fixed them, but there may yet be other functions where using python3 would throw an error.