### PR TITLE
Added tox.ini file for automated testing of multiple python environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ config/
 *.html
 htmlcov/
 .coverage
+coverage.xml
 .tox/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ var/
 *.egg
 config/
 *.html
+htmlcov/
+.coverage
+.tox/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from setuptools import setup
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = clean,py{27,34},stats
+
+[testenv]
+commands =
+  coverage run --source autoprotocol -a setup.py test
+deps =
+  coverage
+
+[testenv:clean]
+commands =
+  coverage erase
+
+[testenv:stats]
+commands =
+  coverage report
+  coverage html

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,4 @@ commands =
 
 [testenv:stats]
 commands =
-  coverage report
-  coverage html
+  coverage report -m


### PR DESCRIPTION
This patch allows developers to test both python2.7 and python3.4 with one command. You first install [tox](https://tox.readthedocs.org/en/latest/) with `pip install tox`, then run tests from then on with `tox`. I'm not sure which CI engine your team uses internally, but tox is also compatible with Jenkins and should help independent contributors test their changes across all environments you choose to support.

Also, tox fetches [coverage](http://nedbatchelder.com/code/coverage/) during testing to list which lines of code in autoprotocol were not executed by the unit tests.