### PR TITLE
harness: add custom temperature for internal use

### DIFF
--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -92,7 +92,7 @@ def convert_param(protocol, val, typeDesc):
         # TODO: this should be a separate 'condition' type, rather than
         # overloading 'temperature'.
         if type == 'temperature' and \
-                val in ['ambient', 'warm_37', 'cold_4', 'cold_20', 'cold_80']:
+                val in ['ambient', 'warm_30', 'warm_37', 'cold_4', 'cold_20', 'cold_80']:
             return val
         else:
             return Unit.fromstring(val)


### PR DESCRIPTION
Adds the `warm_30` temperature.  This is an oddball temperature that should only be used by those who know they can use it.