### PR TITLE
Support int * Unit

### DIFF
--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -93,6 +93,8 @@ class Unit(object):
             other = other.value
         return Unit(self.value * other, self.unit)
 
+    __rmul__ = __mul__
+
     def __div__(self, other):
         if isinstance(other, Unit):
             print("WARNING: Unit.__mul__ and __div__ only support scalar "

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -10,6 +10,7 @@ class UnitMathTestCase(unittest.TestCase):
         self.assertEqual(Unit(-10, 'microliter'), u1 - u2)
         self.assertEqual(Unit(10, 'microliter'), u2 - u1)
         self.assertEqual(Unit(600,'microliter'), u2 * u1.value)
+        self.assertEqual(Unit(600,'microliter'), u2.value * u1)
         self.assertEqual(Unit(1.5, 'microliter'), u2 / u1.value)
         self.assertEqual(Unit(1, 'microliter'), u2//u1)
 


### PR DESCRIPTION
This PR adds support to perform ```int * Unit``` previously only ```Unit * int``` was supported. In reference to #72 