### PR TITLE
Fixed a (really minor) potential crash bug

### DIFF
--- a/autoprotocol/pipette_tools.py
+++ b/autoprotocol/pipette_tools.py
@@ -1,3 +1,5 @@
+import sys
+
 def aspirate_source(depth=None, aspirate_speed=None, cal_volume=None,
                     primer_vol=None):
     '''


### PR DESCRIPTION
This would crash without sys imported.

I mean, the crash only happens on the call to sys.exit, so that’s not so bad, but y'know.

Context: https://transcriptic.slack.com/archives/D0BEF5DD2/p1444075059000008