### PR TITLE
Add extensions to Spetrophotometry instructions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 ## Unreleased
 ---
 Added
+- additional parameters to spectrophotometry instructions (absorbance, luminescence, fluorescence) to instruction.py and protocol.py
+- helper function in util.py to create incubation dictionaries
 
 Changed
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -478,18 +478,34 @@ class Absorbance(Instruction):
     dataref : str
         name of this specific dataset of measured absorbances
     flashes : int, optional
+    incubate_before: dict, optional
+        incubation prior to reading if desired
+        shake: dict, optional
+            shake parameters if desired
+                amplitude: str, Unit
+                    amplitude of shaking between 1 and 6:millimeter
+                orbital: bool
+                    True for oribital and False for linear shaking
+        duration: str, Unit, optional
+            time prior to plate reading
+    temperature: str, Unit, optional
+        set temperature to heat plate reading chamber
 
     """
 
-    def __init__(self, ref, wells, wavelength, dataref, flashes=25):
-        super(Absorbance, self).__init__({
-            "op": "absorbance",
-            "object": ref,
-            "wells": wells,
-            "wavelength": wavelength,
-            "num_flashes": flashes,
-            "dataref": dataref
-        })
+    def __init__(self, ref, wells, wavelength, dataref, flashes=25, incubate_before=None, temperature=None):
+        json_dict = {"op": "absorbance",
+                     "object": ref,
+                     "wells": wells,
+                     "wavelength": wavelength,
+                     "num_flashes": flashes,
+                     "dataref": dataref}
+        if incubate_before:
+            json_dict["incubate_before"] = incubate_before
+        if temperature:
+            json_dict["temperature"] = temperature
+
+        super(Absorbance, self).__init__(json_dict)
 
 
 class Fluorescence(Instruction):
@@ -512,19 +528,36 @@ class Fluorescence(Instruction):
     dataref : str
         name of this specific dataset of measured absorbances
     flashes : int, optional
+    incubate_before: dict, optional
+        incubation prior to reading if desired
+        shake: dict, optional
+            shake parameters if desired
+                amplitude: str, Unit
+                    amplitude of shaking between 1 and 6:millimeter
+                orbital: bool
+                    True for oribital and False for linear shaking
+        duration: str, Unit, optional
+            time prior to plate reading
+    temperature: str, Unit, optional
+        set temperature to heat plate reading chamber
 
     """
 
-    def __init__(self, ref, wells, excitation, emission, dataref, flashes=25):
-        super(Fluorescence, self).__init__({
+    def __init__(self, ref, wells, excitation, emission, dataref, flashes=25,  incubate_before=None, temperature=None):
+        json_dict = {
             "op": "fluorescence",
             "object": ref,
             "wells": wells,
             "excitation": excitation,
             "emission": emission,
             "num_flashes": flashes,
-            "dataref": dataref
-        })
+            "dataref": dataref}
+        if incubate_before:
+            json_dict["incubate_before"] = incubate_before
+        if temperature:
+            json_dict["temperature"] = temperature
+
+        super(Fluorescence, self).__init__(json_dict)
 
 
 class Luminescence(Instruction):
@@ -538,16 +571,34 @@ class Luminescence(Instruction):
     wells : list, WellGroup
         WellGroup or list of wells to be measured
     dataref : str
+    incubate_before: dict, optional
+        incubation prior to reading if desired
+        shake: dict, optional
+            shake parameters if desired
+                amplitude: str, Unit
+                    amplitude of shaking between 1 and 6:millimeter
+                orbital: bool
+                    True for oribital and False for linear shaking
+        duration: str, Unit, optional
+            time prior to plate reading
+    temperature: str, Unit, optional
+        set temperature to heat plate reading chamber
 
     """
 
-    def __init__(self, ref, wells, dataref):
-        super(Luminescence, self).__init__({
+    def __init__(self, ref, wells, dataref, incubate_before=None, temperature=None):
+        json_dict = {
             "op": "luminescence",
             "object": ref,
             "wells": wells,
             "dataref": dataref
-        })
+        }
+        if incubate_before:
+            json_dict["incubate_before"] = incubate_before
+        if temperature:
+            json_dict["temperature"] = temperature
+
+        super(Luminescence, self).__init__(json_dict)
 
 
 class Seal(Instruction):

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -2749,7 +2749,7 @@ class Protocol(object):
                         melting_end, melting_increment, melting_rate))
 
     def incubate(self, ref, where, duration, shaking=False, co2=0):
-        '''
+        """
         Move plate to designated thermoisolater or ambient area for incubation
         for specified duration.
 
@@ -2786,10 +2786,10 @@ class Protocol(object):
                 }
               ]
 
-        '''
+        """
         self.instructions.append(Incubate(ref, where, duration, shaking, co2))
 
-    def absorbance(self, ref, wells, wavelength, dataref, flashes=25):
+    def absorbance(self, ref, wells, wavelength, dataref, flashes=25, incubate_before=None, temperature=None):
         """
         Read the absorbance for the indicated wavelength for the indicated
         wells. Append an Absorbance instruction to the list of instructions for
@@ -2847,6 +2847,18 @@ class Protocol(object):
         dataref : str
             name of this specific dataset of measured absorbances
         flashes : int, optional
+        incubate_before: dict, optional
+            incubation prior to reading if desired
+            shake: dict, optional
+                shake parameters if desired
+                    amplitude: str, Unit
+                        amplitude of shaking between 1 and 6:millimeter
+                    orbital: bool
+                        True for oribital and False for linear shaking
+            duration: str, Unit, optional
+                time prior to plate reading
+        temperature: str, Unit, optional
+            set temperature to heat plate reading chamber
 
         """
         if isinstance(wells, Well):
@@ -2854,10 +2866,10 @@ class Protocol(object):
         if isinstance(wells, WellGroup):
             wells = wells.indices()
         self.instructions.append(
-            Absorbance(ref, wells, wavelength, dataref, flashes))
+            Absorbance(ref, wells, wavelength, dataref, flashes, incubate_before, temperature))
 
     def fluorescence(self, ref, wells, excitation, emission, dataref,
-                     flashes=25):
+                     flashes=25, incubate_before=None, temperature=None):
         """
         Read the fluoresence for the indicated wavelength for the indicated
         wells.  Append a Fluorescence instruction to the list of instructions
@@ -2921,6 +2933,18 @@ class Protocol(object):
             Name of this specific dataset of measured absorbances
         flashes : int, optional
             Number of flashes.
+        incubate_before: dict, optional
+            incubation prior to reading if desired
+            shake: dict, optional
+                shake parameters if desired
+                    amplitude: str, Unit
+                        amplitude of shaking between 1 and 6:millimeter
+                    orbital: bool
+                        True for oribital and False for linear shaking
+            duration: str, Unit, optional
+                time prior to plate reading
+        temperature: str, Unit, optional
+            set temperature to heat plate reading chamber
 
         """
         if isinstance(wells, Well):
@@ -2928,9 +2952,9 @@ class Protocol(object):
         if isinstance(wells, WellGroup):
             wells = wells.indices()
         self.instructions.append(
-            Fluorescence(ref, wells, excitation, emission, dataref, flashes))
+            Fluorescence(ref, wells, excitation, emission, dataref, flashes, incubate_before, temperature))
 
-    def luminescence(self, ref, wells, dataref):
+    def luminescence(self, ref, wells, dataref, incubate_before=None, temperature=None):
         """
         Read luminescence of indicated wells.
 
@@ -2981,13 +3005,24 @@ class Protocol(object):
             WellGroup or list of wells to be measured
         dataref : str
             Name of this dataset of measured luminescence readings.
-
+        incubate_before: dict, optional
+            incubation prior to reading if desired
+            shake: dict, optional
+                shake parameters if desired
+                    amplitude: str, Unit
+                        amplitude of shaking between 1 and 6:millimeter
+                    orbital: bool
+                        True for oribital and False for linear shaking
+            duration: str, Unit, optional
+                time prior to plate reading
+        temperature: str, Unit, optional
+            set temperature to heat plate reading chamber
         """
         if isinstance(wells, Well):
             wells = WellGroup(wells)
         if isinstance(wells, WellGroup):
             wells = wells.indices()
-        self.instructions.append(Luminescence(ref, wells, dataref))
+        self.instructions.append(Luminescence(ref, wells, dataref, incubate_before, temperature))
 
     def gel_separate(self, wells, volume, matrix, ladder, duration, dataref):
         """

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -274,3 +274,46 @@ def deep_merge_params(defaults, override):
             defaults[key] = value
 
     return defaults
+
+
+def incubate_params(duration, shake_amplitude=None, shake_orbital=None):
+    """
+    Create a dictionary with incubation parameters which can be used as input
+    for instructions. Currenly supports plate reader instructions and could be
+    extended for use with other instructions.
+
+    Parameters
+    ----------
+    shake_amplitude: str, Unit
+        amplitude of shaking between 1 and 6:millimeter
+    shake_orbital: bool
+        True for oribital and False for linear shaking
+    duration: str, Unit
+        time for shaking
+    """
+
+    incubate_dict = {}
+    if Unit.fromstring(duration) < Unit.fromstring("0:second"):
+        raise ValueError("duration: %s must be positive" % duration)
+    else:
+        incubate_dict["duration"] = duration
+
+    if (shake_amplitude is not None) and (shake_orbital is not None):
+        shake_dict = {}
+
+        if Unit.fromstring(shake_amplitude) < Unit.fromstring("0:millimeter"):
+            raise ValueError("shake_amplitude: %s must be positive" % shake_amplitude)
+        else:
+            shake_dict["amplitude"] = shake_amplitude
+
+        if not isinstance(shake_orbital, bool):
+            raise ValueError("shake_orbital: %s must be a boolean" % shake_orbital)
+        else:
+            shake_dict["orbital"] = shake_orbital
+
+        incubate_dict["shaking"] = shake_dict
+
+    if (shake_amplitude is not None) ^ (shake_orbital is not None):
+        raise RuntimeError("Both `shake_amplitude`: %s and `shake_orbital`: %s must not be None for shaking to be set" % (shake_amplitude, shake_orbital))
+
+    return incubate_dict

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -742,6 +742,53 @@ class AbsorbanceTestCase(unittest.TestCase):
                      "test_reading")
         self.assertTrue(isinstance(p.instructions[0].wells, list))
 
+    def test_temperature(self):
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.absorbance(test_plate, test_plate.well(0), "475:nanometer",
+                     "test_reading", temperature="30:celsius")
+        self.assertEqual(p.instructions[0].temperature, "30:celsius")
+
+    def test_incubate(self):
+        from autoprotocol.util import incubate_params
+
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.absorbance(test_plate, test_plate.well(0), "475:nanometer",
+                     "test_reading",
+                     incubate_before=incubate_params(
+                                                     "10:second",
+                                                     "3:millimeter",
+                                                     True
+                                                     )
+                     )
+
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["orbital"], True)
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["amplitude"], "3:millimeter")
+        self.assertEqual(p.instructions[0].incubate_before["duration"], "10:second")
+
+        p.absorbance(test_plate, test_plate.well(0), "475:nanometer",
+                     "test_reading",
+                     incubate_before=incubate_params("10:second"))
+
+        self.assertFalse("shaking" in p.instructions[1].incubate_before)
+        self.assertEqual(p.instructions[1].incubate_before["duration"], "10:second")
+
+        with self.assertRaises(ValueError):
+            p.absorbance(test_plate, test_plate.well(0), "475:nanometer", "test_reading", incubate_before=incubate_params("10:second", "-3:millimeter", True))
+
+        with self.assertRaises(ValueError):
+            p.absorbance(test_plate, test_plate.well(0), "475:nanometer", "test_reading", incubate_before=incubate_params("10:second", "3:millimeter", "foo"))
+
+        with self.assertRaises(ValueError):
+            p.absorbance(test_plate, test_plate.well(0), "475:nanometer", "test_reading", incubate_before=incubate_params("-10:second", "3:millimeter", True))
+
+        with self.assertRaises(RuntimeError):
+            p.absorbance(test_plate, test_plate.well(0), "475:nanometer", "test_reading", incubate_before=incubate_params("10:second", "3:millimeter"))
+
+        with self.assertRaises(RuntimeError):
+            p.absorbance(test_plate, test_plate.well(0), "475:nanometer", "test_reading", incubate_before=incubate_params("10:second", shake_orbital=True))
+
 
 class FluorescenceTestCase(unittest.TestCase):
     def test_single_well(self):
@@ -752,6 +799,51 @@ class FluorescenceTestCase(unittest.TestCase):
                        dataref="test_reading")
         self.assertTrue(isinstance(p.instructions[0].wells, list))
 
+    def test_temperature(self):
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", temperature="30:celsius")
+        self.assertEqual(p.instructions[0].temperature, "30:celsius")
+
+    def test_incubate(self):
+        from autoprotocol.util import incubate_params
+
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.fluorescence(test_plate, test_plate.well(0),
+                       excitation="587:nanometer", emission="610:nanometer",
+                       dataref="test_reading",
+                       incubate_before=incubate_params("10:second",
+                                                       "3:millimeter",
+                                                       True))
+
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["orbital"], True)
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["amplitude"], "3:millimeter")
+        self.assertEqual(p.instructions[0].incubate_before["duration"], "10:second")
+
+        p.fluorescence(test_plate, test_plate.well(0),
+                       excitation="587:nanometer", emission="610:nanometer",
+                       dataref="test_reading",
+                       incubate_before=incubate_params("10:second"))
+
+        self.assertFalse("shaking" in p.instructions[1].incubate_before)
+        self.assertEqual(p.instructions[1].incubate_before["duration"], "10:second")
+
+        with self.assertRaises(ValueError):
+            p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", incubate_before=incubate_params("10:second", "-3:millimeter", True))
+
+        with self.assertRaises(ValueError):
+            p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", incubate_before=incubate_params("10:second", "3:millimeter", "foo"))
+
+        with self.assertRaises(ValueError):
+            p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", incubate_before=incubate_params("-10:second", "3:millimeter", True))
+
+        with self.assertRaises(RuntimeError):
+            p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", incubate_before=incubate_params("10:second", "3:millimeter"))
+
+        with self.assertRaises(RuntimeError):
+            p.fluorescence(test_plate, test_plate.well(0), excitation="587:nanometer", emission="610:nanometer", dataref="test_reading", incubate_before=incubate_params("10:second", shake_orbital=True))
+
 
 class LuminescenceTestCase(unittest.TestCase):
     def test_single_well(self):
@@ -759,6 +851,47 @@ class LuminescenceTestCase(unittest.TestCase):
         test_plate = p.ref("test", None, "96-flat", discard=True)
         p.luminescence(test_plate, test_plate.well(0), "test_reading")
         self.assertTrue(isinstance(p.instructions[0].wells, list))
+
+    def test_temperature(self):
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.luminescence(test_plate, test_plate.well(0), "test_reading", temperature="30:celsius")
+        self.assertEqual(p.instructions[0].temperature, "30:celsius")
+
+    def test_incubate(self):
+        from autoprotocol.util import incubate_params
+
+        p = Protocol()
+        test_plate = p.ref("test", None, "96-flat", discard=True)
+        p.luminescence(test_plate, test_plate.well(0), "test_reading",
+                       incubate_before=incubate_params("10:second",
+                                                       "3:millimeter",
+                                                       True))
+
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["orbital"], True)
+        self.assertEqual(p.instructions[0].incubate_before["shaking"]["amplitude"], "3:millimeter")
+        self.assertEqual(p.instructions[0].incubate_before["duration"], "10:second")
+
+        p.luminescence(test_plate, test_plate.well(0), "test_reading",
+                       incubate_before=incubate_params("10:second"))
+
+        self.assertFalse("shaking" in p.instructions[1].incubate_before)
+        self.assertEqual(p.instructions[1].incubate_before["duration"], "10:second")
+
+        with self.assertRaises(ValueError):
+            p.luminescence(test_plate, test_plate.well(0), "test_reading", incubate_before=incubate_params("10:second", "-3:millimeter", True))
+
+        with self.assertRaises(ValueError):
+            p.luminescence(test_plate, test_plate.well(0), "test_reading", incubate_before=incubate_params("10:second", "3:millimeter", "foo"))
+
+        with self.assertRaises(ValueError):
+            p.luminescence(test_plate, test_plate.well(0), "test_reading", incubate_before=incubate_params("-10:second", "3:millimeter", True))
+
+        with self.assertRaises(RuntimeError):
+            p.luminescence(test_plate, test_plate.well(0), "test_reading", incubate_before=incubate_params("10:second", "3:millimeter"))
+
+        with self.assertRaises(RuntimeError):
+            p.luminescence(test_plate, test_plate.well(0), "test_reading", incubate_before=incubate_params("10:second", shake_orbital=True))
 
 
 class AcousticTransferTestCase(unittest.TestCase):


### PR DESCRIPTION
absorbance, luminescence, fluorescence with incubate_before and temperature

Summary:

Extend functionality of spectrophotometry instructions (absorbance, luminescence, fluorescence)
Included a function to create incubation dictionaries
This update implements changes propsed by the "Add incubate_before and temperature to spectrophotometry instructions" ASC
https://docs.google.com/document/d/1xlTz4bEd4_fOjCu6MmFrrKA-IqTRgLKuJxu3EScud9c/edit

Test Plan: passes tox
