### PR TITLE
Changes to acoustic transfer and mix

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -2418,14 +2418,6 @@ class Protocol(object):
                     "repetitions": repetitions
                 }
                 self._pipette([{"mix": [opts]}])
-        for w in well.wells:
-            opts = {
-                "well": w,
-                "volume": volume,
-                "speed": speed,
-                "repetitions": repetitions
-            }
-            self._pipette([{"mix": [opts]}])
 
     def dispense(self, ref, reagent, columns, speed_percentage=None):
         """

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1249,7 +1249,7 @@ class Protocol(object):
         vol_errors = []
         for vol_d in volume:
             if not (vol_d/droplet_size)._magnitude.is_integer():
-                vol_errors.append(vol)
+                vol_errors.append(vol_d)
         if len(vol_errors) > 0:
             raise RuntimeError("Transfer volume has to be a multiple of "
                                "the droplet size. This is not true for the "

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -1123,6 +1123,34 @@ class AcousticTransferTestCase(unittest.TestCase):
         self.assertTrue(
             p.instructions[-1].data["groups"][0]["transfer"][0]["from"] == echo.well(0))
 
+    def test_droplet_size(self):
+        p = Protocol()
+        echo = p.ref("echo", None, "384-echo", discard=True)
+        dest = p.ref("dest", None, "384-flat", discard=True)
+        with self.assertRaises(RuntimeError):
+            p.acoustic_transfer(echo.wells(0, 1).set_volume("2:microliter"),
+                                dest.wells(0, 1), "1:microliter",
+                                droplet_size="26:nanoliter")
+        with self.assertRaises(RuntimeError):
+            p.acoustic_transfer(echo.wells(0, 1).set_volume("2:microliter"),
+                                dest.wells(0, 1), "1.31:microliter")
+
+class MixTestCase(unittest.TestCase):
+
+    def test_mix(self):
+        p = Protocol()
+        w = p.ref("test", None, "micro-1.5", discard=True).well(0).set_volume("20:microliter")
+        p.mix(w, "5:microliter")
+        self.assertEqual(Unit(20, "microliter"), w.volume)
+        self.assertTrue("mix" in p.instructions[-1].groups[-1])
+
+    def test_mix_one_tip(self):
+        p = Protocol()
+        c = p.ref("test", None, "96-flat", discard=True)
+        p.mix(c.wells(0, 1, 2), "5:microliter", one_tip=False)
+        self.assertEqual(len(p.instructions[-1].groups), 3)
+        p.mix(c.wells(0, 1, 2, 4), "5:microliter", one_tip=True)
+        self.assertEqual(len(p.instructions[-1].groups), 4)
 
 class MagneticTransferTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Acoustic transfer now ensures that the volume pipetted is droplet_size compatible and on one_source only generates droplet_size compatible transfers.
mix now takes a one_tip true parameter