### PR TITLE
Distribute Instruction Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Removed
 
 Fixed
 - cover_types on 96-deep-kf and 96-deep
+- dispense_speed and distribute_target in Distribute instruction
 
 ## v3.7.5 - 2016-07-08
 ---

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -827,7 +827,7 @@ class Protocol(object):
 
         opts = {}
         try:
-            dists = self.fill_wells(dest, source, volume, distribute_target)
+            dists = self.fill_wells(dest, source, volume, distribute_target, dispense_speed)
         except ValueError:
             raise RuntimeError("When distributing liquid, source well(s) "
                                "must have an associated volume (aliquot).")
@@ -852,7 +852,7 @@ class Protocol(object):
             opts["to"] = d["to"]
 
             # Append transfer options
-            opt_list = ["aspirate_speed", "allow_carryover", "dispense_speed"]
+            opt_list = ["aspirate_speed", "allow_carryover"]
             for option in opt_list:
                 assign(opts, option, eval(option))
             x_opt_list = ["x_aspirate_source", "x_pre_buffer",
@@ -5319,7 +5319,7 @@ class Protocol(object):
                 return k
 
     @staticmethod
-    def fill_wells(dst_group, src_group, volume, distribute_target):
+    def fill_wells(dst_group, src_group, volume, distribute_target, dispense_speed):
         """
         Distribute liquid to a WellGroup, sourcing the liquid from a group
         of wells all containing the same substance.
@@ -5381,6 +5381,8 @@ class Protocol(object):
             }
             if distribute_target:
                 opts["x_dispense_target"] = distribute_target
+            if dispense_speed:
+                opts["dispense_speed"] = dispense_speed
             distributes[-1]["to"].append(opts)
             src.volume -= v
             if d.volume:

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -967,7 +967,7 @@ class Protocol(object):
         flowrate : str, Unit, optional
             Speed at which to mix liquid in well before and/or after each
             transfer step.
-        aspirate speed : str, Unit, optional
+        aspirate_speed : str, Unit, optional
             Speed at which to aspirate liquid from source well.  May not be
             specified if aspirate_source is also specified. By default this is
             the maximum aspiration speed, with the start speed being half of
@@ -5319,7 +5319,7 @@ class Protocol(object):
                 return k
 
     @staticmethod
-    def fill_wells(dst_group, src_group, volume, distribute_target, dispense_speed):
+    def fill_wells(dst_group, src_group, volume, distribute_target=None, dispense_speed=None):
         """
         Distribute liquid to a WellGroup, sourcing the liquid from a group
         of wells all containing the same substance.

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -661,9 +661,10 @@ class Protocol(object):
     def distribute(self, source, dest, volume, allow_carryover=False,
                    mix_before=False, mix_vol=None, repetitions=10,
                    flowrate="100:microliter/second", aspirate_speed=None,
-                   aspirate_source=None, distribute_target=None,
-                   pre_buffer=None, disposal_vol=None, transit_vol=None,
-                   blowout_buffer=None, tip_type=None, new_group=False):
+                   aspirate_source=None, dispense_speed=None,
+                   distribute_target=None, pre_buffer=None, disposal_vol=None,
+                   transit_vol=None, blowout_buffer=None, tip_type=None,
+                   new_group=False):
         """
         Distribute liquid from source well(s) to destination wells(s).
 
@@ -777,20 +778,23 @@ class Protocol(object):
             liquid in a well before liquid is distributed.
         flowrate : str, Unit, optional
             Speed at which to mix liquid in well before liquid is distributed.
-        aspirate speed : str, Unit, optional
+        aspirate_speed : str, Unit, optional
             Speed at which to aspirate liquid from source well.  May not be
             specified if aspirate_source is also specified. By default this is
             the maximum aspiration speed, with the start speed being half of
             the speed specified.
         aspirate_source : fn, optional
             Can't be specified if aspirate_speed is also specified.
+        dispense_speed : str, Unit, optional
+            Speed at which to dispense liquid into the destination well.  May
+            not be specified if dispense_target is also specified.
         distribute_target : fn, optional
             A function that contains additional parameters for distributing to
             target wells including depth, dispense_speed, and calibrated
             volume.
             If this parameter is specified, the same parameters will be
             applied to every destination well.
-            Can't be specified if dispense_speed is also specified.
+            Will supersede dispense_speed parameters if also specified.
         pre_buffer : str, Unit, optional
             Volume of air aspirated before aspirating liquid.
         disposal_vol : str, Unit, optional
@@ -848,7 +852,7 @@ class Protocol(object):
             opts["to"] = d["to"]
 
             # Append transfer options
-            opt_list = ["aspirate_speed", "allow_carryover"]
+            opt_list = ["aspirate_speed", "allow_carryover", "dispense_speed"]
             for option in opt_list:
                 assign(opts, option, eval(option))
             x_opt_list = ["x_aspirate_source", "x_pre_buffer",
@@ -5376,7 +5380,7 @@ class Protocol(object):
                 "volume": v
             }
             if distribute_target:
-                opts["distribute_target"] = distribute_target
+                opts["x_dispense_target"] = distribute_target
             distributes[-1]["to"].append(opts)
             src.volume -= v
             if d.volume:

--- a/docs/setup.py
+++ b/docs/setup.py
@@ -5,6 +5,6 @@ setup(
     url='http://github.com/autoprotocol/autoprotocol-python',
     author='Vanessa Biggers',
     author_email="vanessa@transcriptic.com",
-    version='3.7.5',
+    version='3.7.6',
     packages=['autoprotocol']
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Vanessa Biggers',
     description='Python library for generating Autoprotocol',
     author_email="vanessa@transcriptic.com",
-    version='3.7.5',
+    version='3.7.6',
     test_suite='test',
     install_requires=[
         'Pint>=0.7.2'

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -257,6 +257,18 @@ class DistributeTestCase(unittest.TestCase):
             p.instructions[-1].groups[0]["distribute"]["to"][
                 0]["volume"]) == "100.0:microliter")
 
+    def test_dispense_speed(self):
+        p = Protocol()
+        c = p.ref("test", None, "96-flat", discard=True)
+        p.distribute(
+            c.well(0).set_volume("100:microliter"), c.well(1), "2:microliter",
+            dispense_speed="150:microliter/second")
+        self.assertTrue("dispense_speed" in p.instructions[-1].groups[-1]["distribute"])
+        p.distribute(
+            c.well(0), c.well(1), "2:microliter",
+            distribute_target={"dispense_speed": "100:microliter/second"})
+        self.assertTrue("x_dispense_target" in p.instructions[-1].groups[-1]["distribute"]["to"][0])
+
 
 class TransferTestCase(unittest.TestCase):
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -263,7 +263,7 @@ class DistributeTestCase(unittest.TestCase):
         p.distribute(
             c.well(0).set_volume("100:microliter"), c.well(1), "2:microliter",
             dispense_speed="150:microliter/second")
-        self.assertTrue("dispense_speed" in p.instructions[-1].groups[-1]["distribute"])
+        self.assertTrue("dispense_speed" in p.instructions[-1].groups[-1]["distribute"]["to"][0])
         p.distribute(
             c.well(0), c.well(1), "2:microliter",
             distribute_target={"dispense_speed": "100:microliter/second"})


### PR DESCRIPTION
Allow `distribute_speed` and properly assign `distribute_target` in the Distribute Instruction.