### PR TITLE
Change default linting engine to pylint

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -1,12 +1,10 @@
 {
   "linters": {
-    "flake8-warning": {
-      "type": "flake8",
+    "pylint": {
+      "type": "pylint",
       "include": "(\\.py$)",
-      "severity": {
-      },
-      "severity.rules": {
-        "(^E)": "warning"
+       "severity.rules": {
+        "(^W)": "advice"
       }
     }
   }

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,20 @@
+[MASTER]
+
+load-plugins=
+    pylint.extensions.docparams,
+
+# Ignore non-python files
+ignore-patterns=
+    ^.*\.(?!py$)[^.]+$
+
+
+[MESSAGES CONTROL]
+
+disable=
+    fixme,
+    wildcard-import,
+    too-many-arguments,
+
+[FORMAT]
+
+max-line-length=80

--- a/.pylintrc
+++ b/.pylintrc
@@ -14,6 +14,7 @@ disable=
     fixme,
     wildcard-import,
     too-many-arguments,
+    too-many-lines,
 
 [FORMAT]
 

--- a/autoprotocol/__init__.py
+++ b/autoprotocol/__init__.py
@@ -8,7 +8,7 @@ class UserError(Exception):
     """Will result in a nice message being displayed to the user."""
 
     def __init__(self, message, info=None):
-        super(Exception, self).__init__(message)
+        super(UserError, self).__init__(message)
         self.info = info
 
     @property

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -11,7 +11,7 @@ import sys
 if sys.version_info[0] >= 3:
     string_type = str
 else:
-    string_type = basestring
+    string_type = basestring  # pylint: disable=undefined-variable
 
 """
     :copyright: 2017 by The Autoprotocol Development Team, see AUTHORS

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1,3 +1,4 @@
+# pragma pylint: disable=too-few-public-methods
 import json
 from .pipette_tools import assign
 from .container import Well

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1,11 +1,9 @@
 from .container import Container, Well, WellGroup, SEAL_TYPES, COVER_TYPES
 from .container_type import ContainerType, _CONTAINER_TYPES
 from .unit import Unit, UnitError
-from .instruction import *  # flake8: noqa
+from .instruction import *  # pylint: disable=unused-wildcard-import
 from .pipette_tools import assign
-from .util import check_valid_origin, check_stamp_append, check_valid_mag, \
-    check_valid_mag_params, check_valid_gel_purify_extract, is_valid_well, \
-    check_valid_incubate_params
+from .util import *  # pylint: disable=unused-wildcard-import
 
 import sys
 if sys.version_info[0] >= 3:
@@ -3635,6 +3633,7 @@ class Protocol(object):
                                  "".format(ts_temp_min, ts_temp_max,
                                            target_temperature))
         if shaking_params:
+            valid_shake_paths = ts_freq_maximums.keys()
             if not isinstance(shaking_params, dict):
                 raise TypeError("'shaking_params' must be a dict "
                                 "containing keys 'frequency' and "
@@ -3643,17 +3642,18 @@ class Protocol(object):
                 raise KeyError("'shaking_params' keys must contain 'frequency' "
                                "and 'path'")
             ts_path = shaking_params["path"]
-            if ts_path not in ts_freq_maximums.keys():
-                "The valid paths for shaking are: {} . You entered {}"
-                "".format(', '.join(ts_freq_maximums.keys()), ts_path)
+            if ts_path not in valid_shake_paths:
+                raise ValueError(
+                    "The valid paths for shaking are: {} . You entered {} ."
+                    "".format(valid_shake_paths, ts_path)
+                )
             frequency = Unit.fromstring(shaking_params["frequency"])
             try:
                 ts_freq_max = ts_freq_maximums[ts_path]
             except KeyError:
                 raise ValueError("An appropriate maximum frequency was not "
                                  "determined for path {}. Valid paths are: {}."
-                                 "".format(ts_path,
-                                           ', '.join(ts_freq_maximums.keys())))
+                                 "".format(ts_path, valid_shake_paths))
             if not (ts_freq_min <= frequency <= ts_freq_max):
                 raise ValueError("The frequency must be between "
                                  "{} and {}, inclusive. You entered {}."
@@ -4741,7 +4741,7 @@ class Protocol(object):
                                 "indicating the colors/channels that this"
                                 " control is to be used for.")
             if (c.get("minimize_bleed") and not
-                    isinstance(p.get("minimize_bleed"), list)):
+                    isinstance(c.get("minimize_bleed"), list)):
                 raise TypeError("Minimize_bleed must be of type list.")
             elif c.get("minimize_bleed"):
                 for b in c["minimize_bleed"]:

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -7,7 +7,7 @@ import sys
 if sys.version_info[0] >= 3:
     string_type = str
 else:
-    string_type = basestring
+    string_type = basestring  # pylint: disable=undefined-variable
 
 """
     :copyright: 2017 by The Autoprotocol Development Team, see AUTHORS

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :support:`-` change default linter to pylint and update tox
+
 * :release:`4.0.0 <2017-11-22>`
 * :feature:`-` add `ceil` and `floor` methods to `Unit`
 * :feature:`-` add shaking capabilities to :ref:`protocol-incubate`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.abspath('../autoprotocol'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'releases'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
         'Pint==0.8.1'
     ],
     tests_require=[
-        'coverage>=4.0.3,<5',
+        'coverage>=4,<5',
         'pylint>=1,<2',
         'pytest>=3,<4',
-        'tox>=2.3.1,<4'
+        'tox>=3,<4'
     ],
     extras_require={
         "docs": [
-            "Sphinx>=1.7,<1.8",
+            "Sphinx>=1.7,<2",
             "sphinx-rtd-theme",
             "releases"
         ]

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,22 @@ setup(
     version='4.0.0',
     test_suite='test',
     install_requires=[
-        'Pint>=0.8.0'
+        'Pint==0.8.1'
     ],
     tests_require=[
-        'pytest>=3.0.0,<4.0',
-        'coverage>=4.0.3',
-        'tox>=2.3.1'
+        'coverage>=4.0.3,<5',
+        'pylint>=1,<2',
+        'pytest>=3,<4',
+        'tox>=2.3.1,<4'
     ],
-    packages=['autoprotocol']
+    extras_require={
+        "docs": [
+            "Sphinx>=1.7,<1.8",
+            "sphinx-rtd-theme",
+            "releases"
+        ]
+    },
+    packages=[
+        'autoprotocol'
+    ]
 )

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -116,8 +116,8 @@ class TestThermocycle:
             ]},
         ], "20:microliter")
         # Test for correct number of groups
-        assert (len(t.groups) == 3)
-        assert (t.volume == "20:microliter")
+        assert (len(t.data["groups"]) == 3)
+        assert (t.data["volume"] == "20:microliter")
 
     def test_thermocycle_dyes_and_datarefs(self):
         pytest.raises(ValueError,

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,33 @@
 [tox]
-envlist = clean,py{27,35},stats
-
-[testenv]
-commands =
-  coverage run --source autoprotocol -a -m pytest
-deps =
-  coverage
-  pytest
+envlist = clean,py{27,35},stats,pylint,docs
 
 [testenv:clean]
 commands =
-  coverage erase
+    coverage erase
+
+[testenv]
+commands =
+    coverage run --source autoprotocol -a -m pytest
+deps =
+    coverage>=4.0.3,<5
+    pylint>=1,<2
+    pytest>=3,<4
 
 [testenv:stats]
 commands =
-  coverage report -m --rcfile={toxinidir}/.coveragerc
+    coverage report -m --rcfile={toxinidir}/.coveragerc
 
-[flake8]
-max-line-length = 80
+[testenv:pylint]
+; disabling Warning, Refactor, and Convention linting
+commands =
+    pylint autoprotocol test --disable=W,R,C
+
+[testenv:docs]
+basepython = python
+changedir = docs
+deps =
+    Sphinx>=1.7,<1.8
+    sphinx_rtd_theme
+    releases
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = clean,py{27,35},stats,pylint,docs
+envlist = clean,py{27,35},stats,lint,docs
+
+[travis]
+python =
+  2.7: clean,py27,stats
+  3.4: clean,py34,stats,lint,docs
 
 [testenv:clean]
 commands =
@@ -17,7 +22,7 @@ deps =
 commands =
     coverage report -m --rcfile={toxinidir}/.coveragerc
 
-[testenv:pylint]
+[testenv:lint]
 ; disabling Warning, Refactor, and Convention linting
 commands =
     pylint autoprotocol test --disable=W,R,C

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ commands =
 commands =
     coverage run --source autoprotocol -a -m pytest
 deps =
-    coverage>=4.0.3,<5
-    pylint>=1,<2
+    coverage>=4,<5
     pytest>=3,<4
+    pylint>=1,<2
 
 [testenv:stats]
 commands =
@@ -25,7 +25,7 @@ commands =
 [testenv:lint]
 ; disabling Warning, Refactor, and Convention linting
 commands =
-    pylint autoprotocol test --disable=W,R,C
+    pylint {toxinidir}/autoprotocol {toxinidir}/test --rcfile={toxinidir}/.pylintrc --disable=W,R,C
 
 [testenv:docs]
 basepython = python
@@ -35,4 +35,4 @@ deps =
     sphinx_rtd_theme
     releases
 commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = clean,py{27,35},stats,lint,docs
 [travis]
 python =
   2.7: clean,py27,stats
-  3.4: clean,py34,stats,lint,docs
+  3.5: clean,py35,stats,lint,docs
 
 [testenv:clean]
 commands =


### PR DESCRIPTION
Pylint allows for much more powerful and configurable linting compared to flake8. In particular this will be really helpful in standardizing docstrings.