### PR TITLE
Fix instruction serialization

### DIFF
--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -8,7 +8,6 @@ Contains all the Autoprotocol Instruction objects
 """
 
 # pragma pylint: disable=too-few-public-methods, redefined-builtin
-import json
 from functools import reduce
 from .builders import *  # pylint: disable=unused-wildcard-import
 
@@ -24,15 +23,18 @@ class Instruction(object):
         self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)
 
-    def json(self):
-        """Return instruction object properly encoded as JSON for Autoprotocol.
+    def __repr__(self):
+        return "Instruction({}, {})".format(self.op, self.data)
 
+    def _as_AST(self):
+        """generates a JSON serializable representation of the Instruction
         Returns
         -------
-        str
-            Instruction object encoded as json string
+        dict
+            A JSON serializable representation of the Instruction
+
         """
-        return json.dumps(dict(op=self.op, **self.data), indent=2)
+        return dict(op=self.op, **self.data)
 
     @staticmethod
     def _remove_empty_fields(data):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -27,11 +27,21 @@ class Instruction(object):
         return "Instruction({}, {})".format(self.op, self.data)
 
     def _as_AST(self):
-        """generates a JSON serializable representation of the Instruction
+        """generates a Python object representation of Autoprotocol JSON
+
         Returns
         -------
         dict
-            A JSON serializable representation of the Instruction
+            a dict of python objects that have the same structure as the
+            Autoprotocol JSON for the Instruction
+
+        Notes
+        -----
+        Used downstream for JSON serialization of the Instruction
+
+        See Also
+        --------
+        Protocol._refify : Protocol serialization method
 
         """
         return dict(op=self.op, **self.data)

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -36,6 +36,9 @@ class Ref(object):
         self.opts = opts
         self.container = container
 
+    def __repr__(self):
+        return "Ref({}, {}, {})".format(self.name, self.container, self.opts)
+
 
 class Protocol(object):
 
@@ -122,6 +125,9 @@ class Protocol(object):
         super(Protocol, self).__init__()
         self.refs = refs or {}
         self.instructions = instructions or []
+
+    def __repr__(self):
+        return "Protocol({})".format(self.__dict__)
 
     def container_type(self, shortname):
         """
@@ -4956,6 +4962,7 @@ class Protocol(object):
 
         return num_containers
 
+    # pylint: disable=protected-access
     def _refify(self, op_data):
         """
         Unpacks protocol objects into Autoprotocol compliant ones
@@ -4985,7 +4992,7 @@ class Protocol(object):
         elif isinstance(op_data, Unit):
             return str(op_data)
         elif isinstance(op_data, Instruction):
-            return self._refify(op_data.__dict__)
+            return self._refify(op_data._as_AST())
         elif isinstance(op_data, Ref):
             return op_data.opts
         else:

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -4985,7 +4985,7 @@ class Protocol(object):
         elif isinstance(op_data, Unit):
             return str(op_data)
         elif isinstance(op_data, Instruction):
-            return self._refify(op_data.data)
+            return self._refify(op_data.__dict__)
         elif isinstance(op_data, Ref):
             return op_data.opts
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`165` update instruction serialization to use a new _as_AST method as op is no longer included in Instruction data
+* :feature:`165` deprecate `Instruction.json` method for now as most instructions contain non-JSON-serializable objects
 * :bug:`167` properly handle `transfer` with tip_type and no volume calibration
 * :feature:`166` add 384-well flat-bottom polystyrene plate containerType
 * :feature:`168` improved pruning of empty data structures from 'Instruction.data' field

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`165` add __repr__ methods to Autoprotocol Python objects
 * :feature:`165` update instruction serialization to use a new _as_AST method as op is no longer included in Instruction data
 * :feature:`165` deprecate `Instruction.json` method for now as most instructions contain non-JSON-serializable objects
 * :bug:`167` properly handle `transfer` with tip_type and no volume calibration

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -303,7 +303,7 @@ class TestRefify(object):
         # refify Instruction
         p.cover(refs["plate"])
         assert (p._refify(p.instructions[0]) == p._refify(
-            p.instructions[0].data))
+            p.instructions[0].__dict__))
 
         # refify Ref
         assert (p._refify(p.refs["test"]) == p.refs["test"].opts)


### PR DESCRIPTION
The `op` field has been removed from `Instruction.data`. The correct way to get an `Instruction`'s full specification is now to reference its `__dict__`.