### PR TITLE
Volume calibration bug fix

### DIFF
--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -280,10 +280,12 @@ class LiquidHandleMethod(object):
         LiquidClass._safe_volume_multiplier : used if no tip_type is specified
         """
 
+        estimated = liquid._safe_volume_multiplier * volume
         if tip_type:
-            cal_vol = liquid._get_calibrated_volume(volume, tip_type)
+            calculated = liquid._get_calibrated_volume(volume, tip_type)
+            cal_vol = calculated if calculated is not None else estimated
         else:
-            cal_vol = liquid._safe_volume_multiplier * volume
+            cal_vol = estimated
 
         return cal_vol
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`167` properly handle `transfer` with tip_type and no volume calibration
 * :support:`164` update `docs/requirements.txt` for rtd to build properly
 * :feature:`163` add liquid_handle instruction (ASC-032)
 * :feature:`163` add LiquidHandleMethods and corresponding protocol methods to represent generic liquid handling abstractions

--- a/test/liquid_handle_unit_test.py
+++ b/test/liquid_handle_unit_test.py
@@ -328,6 +328,16 @@ class TestLiquidHandleMethod(LiquidHandleMethodTester):
         )
         assert estimated_calibrated_volume == target_volume * volume_multiplier
 
+    def test_estimate_calibrated_volume_with_tip_but_not_calibration(self):
+        target_volume = Unit(1, "uL")
+        volume_multiplier = LiquidClass()._safe_volume_multiplier
+        estimated_calibrated_volume = self.lhm._estimate_calibrated_volume(
+            volume=target_volume,
+            liquid=LiquidClass(),
+            tip_type="generic_96_180"
+        )
+        assert estimated_calibrated_volume == target_volume * volume_multiplier
+
 
 class TransferMethodTester(object):
     single_shape = LiquidHandle.builders.shape(1, 1, "SBS96")


### PR DESCRIPTION
Summary: Fix a bug in which LiquidClass._get_calibrated_volume was returning a None which was not being properly handled.

Test Plan: pytest

Reviewers: varun, yangchoo, dbdalton

Differential Revision: https://work.r23s.net/D11061