### PR TITLE
avoid returning empty dict/list

### DIFF
--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -21,7 +21,7 @@ class Instruction(object):
     def __init__(self, op, data):
         super(Instruction, self).__init__()
         self.op = op
-        self.data = self._remove_empty_fields(data)
+        self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)
 
     def json(self):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`165` improved pruning of empty data structures from 'Instruction.data' field
 * :support:`164` update `docs/requirements.txt` for rtd to build properly
 * :feature:`163` add liquid_handle instruction (ASC-032)
 * :feature:`163` add LiquidHandleMethods and corresponding protocol methods to represent generic liquid handling abstractions

--- a/test/instruction_test.py
+++ b/test/instruction_test.py
@@ -49,6 +49,20 @@ class TestBaseInstruction(object):
                Instruction._remove_empty_fields(
                    [dict(some_bool=True, empty=[])])
 
+        assert Instruction(op="some instruction",
+                           data={
+                               "not_empty": {"foo": "bar"},
+                               "empty": {
+                                   "foo": None, "bar": None
+                               }
+                           }).data == {"not_empty": {"foo": "bar"}}
+
+        assert Instruction(op="some instruction",
+                           data={
+                               "not_empty": ["foo", "bar"],
+                               "empty": [None, None]
+                           }).data == {"not_empty": ["foo", "bar"]}
+
     @staticmethod
     def test_op(test_instruction):
         assert test_instruction.op == "test_instruction"


### PR DESCRIPTION
Summary:
empty list/dicts should not end up in the final autoprotol json. a single call to _remove_empty_fields does will return an empty dict for cases in which a dict is given with values that are all None, and will return an empty list for cases in which a list is passed with all None elements.

ex:
```
foo = {"not_empty": 1, "empty": {"a": None, "b": None, "c": None}}
Instruction._remove_empty_fields(foo)
>>> {'not_empty': 1, 'empty': {}}

Instruction._remove_empty_fields(Instruction._remove_empty_fields(foo))
>>> {'not_empty': 1}

foo = {"not_empty": 1, "empty": [None, None, None]}
Instruction._remove_empty_fields(foo)
>>> {'not_empty': 1, 'empty': []}

Instruction._remove_empty_fields(Instruction._remove_empty_fields(foo))
>>> {'not_empty': 1}
```

Test Plan: pytest

Reviewers: yangchoo, rhys, varun

Differential Revision: https://work.r23s.net/D11052