### PR TITLE
Refactor LiHa defaults

### DIFF
--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -654,7 +654,10 @@ class LiquidHandleMethod(object):
             pre_buffer = parse_unit(pre_buffer, "uL")
             self._aspirate_simple(
                 volume=pre_buffer,
-                initial_z=self.default_well_top_position_z(),
+                initial_z=LiquidHandle.builders.position_z(
+                    reference="well_top",
+                    offset="1:mm"
+                ),
                 liquid_class="air"
             )
 
@@ -785,6 +788,5 @@ class LiquidHandleMethod(object):
             position_z for the well top
         """
         return LiquidHandle.builders.position_z(
-            reference="well_top",
-            offset="-2:mm"
+            reference="well_top"
         )

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -625,9 +625,6 @@ class PreMixBlowoutTransfer(Transfer):
         )
         self.pre_mix_blowout = pre_mix_blowout
 
-    def default_dispense_z(self, volume):
-        return self.default_tracked_position_z()
-
     def _dispense_transports(self, volume=None):
         self._transports = []
         volume = parse_unit(volume, "ul")
@@ -645,20 +642,26 @@ class PreMixBlowoutTransfer(Transfer):
         return self._transports
 
     def _calculate_pre_buffer(self, volume):
-        if self.blowout is not False:
-            blowout = self.blowout or self.default_blowout(volume)
-            blowout_vol = blowout.get("volume")
+        if self.blowout is True:
+            blowout = self.default_blowout(volume)
+        elif self.blowout is False:
+            blowout = {}
         else:
-            blowout_vol = Unit("0:uL")
+            blowout = self.blowout
 
-        if self.pre_mix_blowout is not False:
-            secondary_blowout = (
-                self.pre_mix_blowout or self.default_pre_mix_blowout(volume)
-            )
-            # pylint: disable=no-member
-            secondary_blowout_vol = secondary_blowout.get("volume")
+        if self.pre_mix_blowout is True:
+            secondary_blowout = self.default_pre_mix_blowout(volume)
+        elif self.pre_mix_blowout is False:
+            secondary_blowout = {}
         else:
-            secondary_blowout_vol = Unit("0:uL")
+            secondary_blowout = self.pre_mix_blowout
+
+        blowout_vol = parse_unit(
+            blowout.get("volume", Unit("0:uL")), "uL"
+        )
+        secondary_blowout_vol = parse_unit(
+            secondary_blowout.get("volume", Unit("0:uL")), "uL"
+        )
 
         return blowout_vol + secondary_blowout_vol
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`174` use more sensible default z positions for pre_buffer and blowout in `LiquidHandleMethod`
+* :bug:`174` fix broken PreMixBlowoutTransfer that used outdated logic
 * :feature:`170` protect liquid_handle-related utils until they can be made more general-purpose
 * :feature:`170` deprecate unused utils including `euclidean_distance`, `quad_ind_to_num`, and `quad_num_to_ind`
 * :feature:`170` port existing checkers to builders format


### PR DESCRIPTION
Update Transfer LiquidHandleMethod defaults to use more sensible z positions; unbreak PreMixBlowoutTransfer.