### PR TITLE
Fix transfer tip_type assignment

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5947,7 +5947,10 @@ class Protocol(object):
         # apply tip types to transfer methods
         for vol, met in zip(volume, method):
             if met._has_calibration() and not met.tip_type:
-                met.tip_type = met._rec_tip_type(vol)
+                try:
+                    met.tip_type = met._rec_tip_type(vol)
+                except RuntimeError:
+                    met.tip_type = met._get_sorted_tip_types()[-1].name
 
         # if one tip is true then all methods need to have the same tip_type
         if one_tip is True:
@@ -6180,7 +6183,10 @@ class Protocol(object):
         # apply tip types to mix methods
         for vol, met in zip(volume, method):
             if met._has_calibration() and not met.tip_type:
-                met.tip_type = met._rec_tip_type(vol)
+                try:
+                    met.tip_type = met._rec_tip_type(vol)
+                except RuntimeError:
+                    met.tip_type = met._get_sorted_tip_types()[-1].name
 
         # if one tip is true then all methods need to have the same tip_type
         if one_tip is True:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`-` fix transfer failing to assign `tip_type` with calibrated transfers that require splitting
+* :bug:`175 major` fix transfer failing to assign `tip_type` with calibrated transfers that require splitting
 * :release:`5.0.0 <2018-08-24>`
 * :feature:`172` add new `FlowCytometry` instruction and corresponding protocol method
 * :feature:`174` use more sensible default z positions for pre_buffer and blowout in `LiquidHandleMethod`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` fix transfer failing to assign `tip_type` with calibrated transfers that require splitting
 * :release:`5.0.0 <2018-08-24>`
 * :feature:`172` add new `FlowCytometry` instruction and corresponding protocol method
 * :feature:`174` use more sensible default z positions for pre_buffer and blowout in `LiquidHandleMethod`


### PR DESCRIPTION
Transfer `tip_type` assignment was breaking on cases where there were the volume is large enough to necessitate splitting.