### PR TITLE
Fix Thermocycle.dyes using Well instead of Int

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -178,8 +178,8 @@ class ThermocycleBuilders(InstructionBuilders):
 
         Parameters
         ----------
-        **kwargs : Well or WellGroup
-            A mapping from a dye (str) to a Well or WellGroup
+        **kwargs : dict(str: int or list(int))
+            A mapping from a dye (str) to the index of a well
 
         Returns
         -------
@@ -190,14 +190,25 @@ class ThermocycleBuilders(InstructionBuilders):
         ------
         ValueError
             If any of the specified dyes are not valid
-
+        ValueError
+            If wells is not an int, str, list(int), or list(str)
         """
-        dyes = {dye: WellGroup(wells) for dye, wells in kwargs.items()}
-        if not all(_ in self.valid_dyes for _ in dyes.keys()):
-            raise ValueError(
-                "dyes: {} was specified but contains a keys that are not in "
-                "the set of accepted dyes: {}".format(dyes, self.valid_dyes)
-            )
+        dyes = {}
+        for dye, wells in kwargs.items():
+            if dye not in self.valid_dyes:
+                raise ValueError(
+                    "dye {} is not in the set of valid dyes {}"
+                    "".format(dye, self.valid_dyes)
+                )
+            if not isinstance(wells, list):
+                wells = [wells]
+            if not all(isinstance(_, (int, str)) for _ in wells):
+                raise ValueError(
+                    "dye {} had wells {} that were not an int, str or list"
+                    "".format(dye, wells)
+                )
+            dyes[dye] = wells
+
         return dyes
 
     def dyes_from_well_map(self, well_map):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`183` fix `ThermocycleBuilders.dyes` to reference ints instead of Wells
+* :support:`184` Improve CI pipeline and fix lint warnings for new versions of pylint
 * :bug:`182` fix `WellGroup` missing equality method
 * :release:`5.2.0 <2018-12-11>`
 * :feature:`180` add support for `read_position` and `position_z` to `spectrophotometry` (ASC-041)

--- a/test/builder_test.py
+++ b/test/builder_test.py
@@ -162,6 +162,25 @@ class TestThermocycleBuilders(object):
             'read': True
         })
 
+    def test_dyes_valid(self):
+        dye_builder = Thermocycle.builders.dyes(
+            FRET=1,
+            FAM=[1, 2]
+        )
+        assert dye_builder == {"FRET": [1], "FAM": [1, 2]}
+
+    def test_dyes_invalid_dye(self):
+        with pytest.raises(ValueError):
+            Thermocycle.builders.dyes(
+                FOO=1
+            )
+
+    def test_dyes_invalid_well(self):
+        with pytest.raises(ValueError):
+            Thermocycle.builders.dyes(
+                FRET={}
+            )
+
 
 def cast_values_as_units(params):
     def to_unit(item):


### PR DESCRIPTION
Thermocycle dyes builder was using wells instead of ints which was not to Autoprotocol spec.