### PR TITLE
Update CI and unbreak existing lint warnings

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -24,13 +24,19 @@ Instruction
     Instructions corresponding to each of the builders
 """
 
-from collections import Iterable, defaultdict
+from collections import defaultdict
 from functools import reduce
+from sys import version_info
 from numbers import Number
 from .constants import SBS_FORMAT_SHAPES
 from .util import parse_unit, is_valid_well
 from .container import WellGroup, Well, Container
 from .unit import Unit
+
+if version_info.major == 3 and version_info.minor >= 3:
+    from collections.abc import Iterable  # pylint: disable=no-name-in-module
+else:
+    from collections import Iterable  # pylint: disable=no-name-in-module
 
 
 class InstructionBuilders(object):  # pylint: disable=too-few-public-methods

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -126,9 +126,9 @@ class ContainerType(namedtuple("ContainerType",
             form. Also accepts lists of str, int or Well.
 
         Returns
-        ----------
-        well_ref : int, list
-            Single or list of Well references passed as rowwise integer
+        -------
+        int or list
+            Single or list of Well references passed as row-wise integer
             (left-to-right, top-to-bottom, starting at 0 = A1).
 
         Raises

--- a/autoprotocol/liquid_handle/liquid_class.py
+++ b/autoprotocol/liquid_handle/liquid_class.py
@@ -261,6 +261,7 @@ class VolumeCalibrationBin(namedtuple("VolumeCalibrationBin",
         Returns
         -------
         VolumeCalibrationBin
+            an object used for linear fitting volumes within a bin
 
         Raises
         ------

--- a/autoprotocol/liquid_handle/tip_type.py
+++ b/autoprotocol/liquid_handle/tip_type.py
@@ -21,11 +21,16 @@ class TipType(namedtuple("TipType", ["name", "volume"])):
         Returns
         -------
         TipType
+            A tip type compatible with LiquidHandleMethods
 
         Raises
         ------
         TypeError
             if the name is not a str
+
+        See Also
+        --------
+        :py:class: `autoprotocol.LiquidHandleMethod._get_tip_types`
         """
         if not isinstance(name, str):
             raise TypeError("TipType name {} was not a str.".format(name))

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -34,6 +34,7 @@ def to_decimal(number):
     Returns
     -------
     Decimal
+        decimal representation of the input number
 
     Raises
     ------

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(
         'future==0.16.0'
     ],
     tests_require=[
-        'coverage>=4,<5',
-        'pylint>=1,<2',
-        'pytest>=3,<4',
-        'tox>=3,<4'
+        'coverage==4.*',
+        'pylint==1.*',
+        'pytest==4.*',
+        'tox==3.*'
     ],
     extras_require={
         "docs": [
-            "Sphinx>=1.7,<2",
+            "Sphinx==1.*",
             "sphinx-rtd-theme",
             "releases"
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,32 @@
 [tox]
-envlist = clean,py{27,35},stats,lint,docs
+envlist = py{27,35},lint,docs
 
 [travis]
 python =
-  2.7: clean,py27,stats
-  3.5: clean,py35,stats,lint,docs
-
-[testenv:clean]
-commands =
-    coverage erase
+  2.7: py27
+  3.5: py35,lint,docs
 
 [testenv]
 commands =
+    coverage erase
     coverage run --source autoprotocol -a -m pytest
-deps =
-    coverage>=4,<5
-    pytest>=3,<4
-    pylint>=1,<2
-
-[testenv:stats]
-commands =
     coverage report -m --rcfile={toxinidir}/.coveragerc
+deps =
+    coverage==4.*
+    pytest==4.*
 
-[testenv:lint]
-; disabling Warning, Refactor, and Convention linting
+[lint:py35]
+deps =
+    pylint==1.*
+    pytest==4.*
+; disabling Refactor, and Convention linting
 commands =
     pylint {toxinidir}/autoprotocol {toxinidir}/test --rcfile={toxinidir}/.pylintrc --disable=R,C
 
-[testenv:docs]
-basepython = python
+[docs:py35]
 changedir = docs
 deps =
-    Sphinx>=1.7,<1.8
+    Sphinx==1.*
     sphinx_rtd_theme
     releases
 commands =


### PR DESCRIPTION
- Make CI dependencies more readable
- Update tox to use specific python versions for docs and linting instead of default system python
- Fix lint warnings introduced by a pylint update
