### PR TITLE
Add flag to propagate aliquot props with liha

### DIFF
--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -99,6 +99,46 @@ class ContainerType(namedtuple("ContainerType",
                                                  cat_no,
                                                  prioritize_seal_or_cover)
 
+    def well_from_coordinates(self, row, column):
+        """
+        Gets the well at 0-indexed position (row, column) within the container.
+        The origin is in the top left corner.
+
+        Parameters
+        ----------
+        row : int
+            The 0-indexed row index of the well to be fetched
+        column : int
+            The 0-indexed column index of the well to be fetched
+
+        Returns
+        -------
+        Int
+            The robotized index of the well at at position (row, column)
+
+        Raises
+        ------
+        ValueError
+            if the specified row is outside the bounds of the container_type
+        ValueError
+            if the specified column is outside the bounds of the container_type
+        """
+        if row >= self.row_count():
+            raise ValueError(
+                "0-indexed row {} is outside of the bounds of {}".format(
+                    row, self
+                )
+            )
+
+        if column >= self.col_count:
+            raise ValueError(
+                "0-indexed column {} is outside of the bounds of {}".format(
+                    column, self
+                )
+            )
+
+        return row * self.col_count + column
+
     def robotize(self, well_ref):
         """
         Return a robot-friendly well reference from a number of well reference
@@ -137,7 +177,8 @@ class ContainerType(namedtuple("ContainerType",
             If well reference given is not an accepted type.
         ValueError
             If well reference given exceeds container dimensions.
-
+        ValueError
+            If well reference given is in an invalid format.
         """
         if isinstance(well_ref, list):
             return [self.robotize(well) for well in well_ref]
@@ -154,15 +195,7 @@ class ContainerType(namedtuple("ContainerType",
         if m:
             row = ord(m.group(1).upper()) - ord('A')
             col = int(m.group(2)) - 1
-            well_num = row * self.col_count + col
-            # Check bounds
-            if row >= self.row_count():
-                raise ValueError("ContainerType.robotize(): Row given exceeds "
-                                 "container dimensions.")
-            if col >= self.col_count or col < 0:
-                raise ValueError("ContainerType.robotize(): Col given exceeds "
-                                 "container dimensions.")
-            return well_num
+            return self.well_from_coordinates(row, col)
         else:
             m = re.match(r"\d+$", well_ref)
             if m:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling; add `Container` utils for selecting wells
 * :support:`187` Remove Phabricator URI from .arcconfig
 * :release:`5.2.1 <2019-01-08>`
 * :bug:`186` Fix well volume math when liquid handling in python2 and add missing seal capability for `384-flat-white-clear`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,9 @@
 Changelog
 =========
 
-* :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling; add `Container` utils for selecting wells
+* :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling
+* :feature:`188` Add `Container` utils for selecting wells
+* :feature:`188` Add support for non-string aliquot property values as long as they're JSON-serializable
 * :support:`187` Remove Phabricator URI from .arcconfig
 * :release:`5.2.1 <2019-01-08>`
 * :bug:`186` Fix well volume math when liquid handling in python2 and add missing seal capability for `384-flat-white-clear`

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+# pragma pylint: disable=missing-docstring
 import pytest
 from autoprotocol.container import Container
 from autoprotocol.container_type import ContainerType
@@ -93,6 +94,75 @@ def dummy_96():
             capabilities=["cover"],
             shortname="dummy",
             col_count=12,
+            dead_volume_ul=Unit(15, "microliter"),
+            safe_min_volume_ul=Unit(30, "microliter")
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def dummy_reservoir_row():
+    return Container(
+        None,
+        ContainerType(
+            name="dummy",
+            well_count=8,
+            well_depth_mm=None,
+            well_volume_ul=Unit(200, "microliter"),
+            well_coating=None,
+            sterile=False,
+            is_tube=False,
+            cover_types=None,
+            seal_types=None,
+            capabilities=None,
+            shortname="dummy",
+            col_count=1,
+            dead_volume_ul=Unit(15, "microliter"),
+            safe_min_volume_ul=Unit(30, "microliter")
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def dummy_reservoir_column():
+    return Container(
+        None,
+        ContainerType(
+            name="dummy",
+            well_count=12,
+            well_depth_mm=None,
+            well_volume_ul=Unit(200, "microliter"),
+            well_coating=None,
+            sterile=False,
+            is_tube=False,
+            cover_types=None,
+            seal_types=None,
+            capabilities=None,
+            shortname="dummy",
+            col_count=12,
+            dead_volume_ul=Unit(15, "microliter"),
+            safe_min_volume_ul=Unit(30, "microliter")
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def dummy_24():
+    return Container(
+        None,
+        ContainerType(
+            name="dummy",
+            well_count=24,
+            well_depth_mm=None,
+            well_volume_ul=Unit(200, "microliter"),
+            well_coating=None,
+            sterile=False,
+            is_tube=False,
+            cover_types=None,
+            seal_types=None,
+            capabilities=None,
+            shortname="dummy",
+            col_count=6,
             dead_volume_ul=Unit(15, "microliter"),
             safe_min_volume_ul=Unit(30, "microliter")
         )

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -205,3 +205,17 @@ class TestExtendedLiquidHandleMethods(LiquidHandleTester):
         assert(
             len(self.p.instructions[0].locations[1]["transports"]) == 6
         )
+
+
+class TestPropagatesAliquotProperties(LiquidHandleTester):
+    def test_doesnt_propagate_properties_by_default(self):
+        self.flat.well(0).add_properties({"propagated": True})
+        self.p.transfer(self.flat.well(0), self.flat.well(1), "5:uL")
+        assert not self.flat.well(1).properties
+
+    def test_propagates_aliquot_properties(self):
+        properties = {"propagated": True}
+        self.p.propagate_properties = True
+        self.flat.well(0).add_properties(properties)
+        self.p.transfer(self.flat.well(0), self.flat.well(1), "5:uL")
+        assert self.flat.well(1).properties == properties

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -5,7 +5,6 @@ from autoprotocol.unit import Unit
 
 
 class TestParseUnit(object):
-
     def test_casting_to_unit(self):
         assert Unit("1:second") == parse_unit("1:second")
         assert Unit("1:ul") == parse_unit("1:microliter")


### PR DESCRIPTION
Add a flag to `Protocol` to propagate aliquot properties when liquid handling.
Add new methods to `Container` and `ContainerType` for fetching WellGroups.