### PR TITLE
Make Well.add_properties extend lists

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -88,10 +88,11 @@ class Well(object):
 
     def add_properties(self, properties):
         """
-        Add properties to the properties attribute of a Well. If any key/value
-        pairs are present in both the old and new dictionaries, they will be
-        overwritten by the pairs in the new dictionary unless both the old and
-        new values are lists which case the new one will be appended to the old.
+        Add properties to the properties attribute of a Well.
+
+        If any property with the same key already exists for the Well then:
+         - if both old and new properties are lists then append the new property
+         - otherwise overwrite the old property with the new one
 
         Parameters
         ----------

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -106,11 +106,11 @@ class Well(object):
         self.validate_properties(properties)
         for key, value in properties.items():
             if key in self.properties:
-                keys_are_lists = all(
+                values_are_lists = all(
                     isinstance(_, list)
                     for _ in [value, self.properties[key]]
                 )
-                if keys_are_lists:
+                if values_are_lists:
                     self.properties[key].extend(value)
                 else:
                     message = "Overwriting existing property {} for {}".format(

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -88,10 +88,10 @@ class Well(object):
 
     def add_properties(self, properties):
         """
-        Add properties to the properties attribute of a Well.
-        If any key/value pairs are present in both the old and
-        new dictionaries, they will be overwritten by the pairs
-        in the new dictionary.
+        Add properties to the properties attribute of a Well. If any key/value
+        pairs are present in both the old and new dictionaries, they will be
+        overwritten by the pairs in the new dictionary unless both the old and
+        new values are lists which case the new one will be appended to the old.
 
         Parameters
         ----------
@@ -106,12 +106,20 @@ class Well(object):
         self.validate_properties(properties)
         for key, value in properties.items():
             if key in self.properties:
-                warnings.warn(
-                    message="Overwriting existing property {} for {}".format(
+                keys_are_lists = all(
+                    isinstance(_, list)
+                    for _ in [value, self.properties[key]]
+                )
+                if keys_are_lists:
+                    self.properties[key].extend(value)
+                else:
+                    message = "Overwriting existing property {} for {}".format(
                         key, self
                     )
-                )
-            self.properties[key] = value
+                    warnings.warn(message=message)
+                    self.properties[key] = value
+            else:
+                self.properties[key] = value
         return self
 
     def set_volume(self, vol):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`189` Make `Well.add_properties` if both values are lists then append to the original instead of replacing it
+* :feature:`190` Make `Well.add_properties` if both values are lists then append to the original instead of replacing it
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling
 * :feature:`188` Add `Container` utils for selecting wells

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`189` Make `Well.add_properties` if both values are lists then append to the original instead of replacing it
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling
 * :feature:`188` Add `Container` utils for selecting wells

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`190` Make `Well.add_properties` if both values are lists then append to the original instead of replacing it
+* :feature:`190` Make Well.add_properties extend the original instead of replacing it if both values are lists
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling
 * :feature:`188` Add `Container` utils for selecting wells

--- a/test/well_test.py
+++ b/test/well_test.py
@@ -1,0 +1,75 @@
+# pragma pylint: disable=missing-docstring,attribute-defined-outside-init
+import warnings
+import pytest
+from autoprotocol.container import Container
+
+class HasDummyWell(object):
+    @pytest.fixture(autouse=True)
+    def make_wells(self, dummy_type):
+        self.container = Container(id=None, container_type=dummy_type)
+        self.well = self.container.well(0)
+
+class TestValidateProperties(HasDummyWell):
+    def test_rejects_incorrect_types(self):
+        with pytest.raises(TypeError):
+            self.well.set_properties(["property", "value"])
+        with pytest.raises(TypeError):
+            self.well.set_properties({"property", True})
+        with pytest.raises(TypeError):
+            self.well.set_properties({("property"), "value"})
+
+    def test_can_use_nonstring_properties(self):
+        self.well.set_properties({"foo": [1, 2, 3]})
+        self.well.add_properties({"bar": [1, 2, 3]})
+
+    def test_fails_to_set_unserializable_property(self):
+        with pytest.raises(TypeError):
+            self.well.set_properties({"test": {1}})
+
+
+class TestSetProperties(HasDummyWell):
+    def test_sets_properties(self):
+        test_property = {"foo": "bar"}
+        self.well.set_properties(test_property)
+        assert self.well.properties == test_property
+
+    def test_overwrites_properties(self):
+        new_property = {"bar": True}
+        self.well.set_properties({"foo": True})
+        self.well.set_properties(new_property)
+        assert self.well.properties == new_property
+
+
+class TestAddProperties(HasDummyWell):
+    def test_adds_properties(self):
+        test_property = {"foo": "bar"}
+        self.well.set_properties(test_property)
+        assert self.well.properties == test_property
+
+    def test_doesnt_overwrite_properties(self):
+        old_property = {"foo": True}
+        new_property = {"bar": False}
+        self.well.add_properties(old_property)
+        self.well.add_properties(new_property)
+        merged_properties = old_property.copy()
+        merged_properties.update(new_property)
+        assert self.well.properties == merged_properties
+
+    def test_add_properties_appends_lists(self):
+        self.well.set_properties({"foo": ["bar"]})
+        self.well.add_properties({"foo": ["baz"]})
+        assert self.well.properties == {"foo": ["bar", "baz"]}
+
+    def test_warns_when_overwriting_property(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.well.set_properties({"foo": "bar"})
+            self.well.add_properties({"foo": "bar"})
+            assert len(w) == 1
+            for message in w:
+                assert "Overwriting existing property" in str(message.message)
+
+    def test_doesnt_warn_when_not_overwriting_property(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.well.set_properties({"field1": True})
+            self.well.add_properties({"field2": False})
+            assert len(w) == 0


### PR DESCRIPTION
 Make `Well.add_properties` extend the original instead of replacing it if both values are lists.