### PR TITLE
Add cover state to ref opts

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -283,6 +283,10 @@ class Protocol(object):
                 "You must specify either a valid storage condition or set "
                 "discard=True for a Ref."
             )
+
+        if cover:
+            opts["cover"] = cover
+
         container = Container(
             id, cont_type, name=name,
             storage=storage if storage else None,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`191` Add initial cover state to ref opts (ASC-42)
+* :feature:`191` Add initial cover state to ref opts (ASC-042)
 * :feature:`190` Make Well.add_properties extend the original instead of replacing it if both values are lists
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`-` Add initial cover state to ref opts
+* :feature:`191` Add initial cover state to ref opts (ASC-42)
 * :feature:`190` Make Well.add_properties extend the original instead of replacing it if both values are lists
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Add initial cover state to ref opts
 * :feature:`190` Make Well.add_properties extend the original instead of replacing it if both values are lists
 * :release:`5.3.0 <2019-02-21>`
 * :feature:`188` Add `Protocol` flag to propagate aliquot properties when liquid handling

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -2,6 +2,7 @@
 # pragma pylint: disable=attribute-defined-outside-init
 import pytest
 from autoprotocol.container import Container, WellGroup
+from autoprotocol.container_type import _CONTAINER_TYPES
 from autoprotocol.instruction import (
     Thermocycle, Incubate, Spin, Dispense, GelPurify,
     Fluorescence, Absorbance, Luminescence, Instruction
@@ -119,6 +120,15 @@ class TestRef(object):
         assert (
             p.as_dict()["refs"]["discard_test"]["store"]["where"] == "cold_4")
     # pragma pylint: enable=expression-not-assigned
+
+    def test_cover_state_propagation(self):
+        for name, ct in _CONTAINER_TYPES.items():
+            for covers in filter(None, [ct.cover_types, ct.seal_types]):
+                for cover in covers:
+                    p = Protocol()
+                    p.ref(name + cover, cont_type=name, cover=cover, discard=True)
+                    ref = list(p.as_dict()["refs"].values())[0]
+                    assert ref["cover"] == cover
 
 
 class TestThermocycle(object):


### PR DESCRIPTION
This diff adds initial cover states of refs to the output of `Protocol.as_dict`.