### PR TITLE
Fix for wells_with to add support for non-str values

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -426,7 +426,7 @@ class WellGroup(object):
         """
         if not isinstance(prop, str):
             raise TypeError("property is not a string: %r" % prop)
-        if val:
+        if val is not None:
             return WellGroup([w for w in self.wells if prop in w.properties and
                              w.properties[prop] is val])
         else:

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -426,8 +426,6 @@ class WellGroup(object):
         """
         if not isinstance(prop, str):
             raise TypeError("property is not a string: %r" % prop)
-        if val is not None and not isinstance(val, str):
-            raise TypeError("value is not a string: %r" % val)
         if val:
             return WellGroup([w for w in self.wells if prop in w.properties and
                              w.properties[prop] is val])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`-` Add support for well properties with non-string values in `wells_with`
+* :bug:`193` Add support for well properties with non-string values in `wells_with`
 
 * :release:`5.4.0 <2019-03-06>`
 * :feature:`191` Add initial cover state to ref opts (ASC-042)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Add support for well properties with non-string values in `wells_with`
+
 * :release:`5.4.0 <2019-03-06>`
 * :feature:`191` Add initial cover state to ref opts (ASC-042)
 * :feature:`190` Make Well.add_properties extend the original instead of replacing it if both values are lists

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -254,6 +254,18 @@ class TestWellGroupList(HasDummyContainers):
         assert (prop_and_val[0] == ws[2])
         assert (prop_and_val[1] == ws[3])
 
+    def test_wells_with_non_string_values(self):
+        # Testing this only for Ints for now. We used to only allow str values
+        ws = self.c.wells_from('A1', 2)
+        ws.set_properties({'property1': 1})
+        ws2 = self.c.wells_from('B1', 2)
+        ws2.set_properties({'property1': 2})
+        both_ws = ws + ws2
+        prop = both_ws.wells_with('property1')
+        assert(prop == both_ws)
+        prop_and_val = both_ws.wells_with('property1', 2)
+        assert(prop_and_val == ws2)
+
     def test_pop(self):
         ws = self.c.wells_from('A1', 3)
         assert (ws[0] == ws.pop(0))

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -255,16 +255,23 @@ class TestWellGroupList(HasDummyContainers):
         assert (prop_and_val[1] == ws[3])
 
     def test_wells_with_non_string_values(self):
-        # Testing this only for Ints for now. We used to only allow str values
-        ws = self.c.wells_from('A1', 2)
-        ws.set_properties({'property1': 1})
-        ws2 = self.c.wells_from('B1', 2)
-        ws2.set_properties({'property1': 2})
-        both_ws = ws + ws2
-        prop = both_ws.wells_with('property1')
-        assert(prop == both_ws)
-        prop_and_val = both_ws.wells_with('property1', 2)
-        assert(prop_and_val == ws2)
+        # Current minimal set of cases, we technically should support any value
+        # that's supported in `set_properties`
+        non_str_test_cases = [
+            (1, 2),
+            (True, False),
+            (0.1, 0.2)
+        ]
+        for (val1, val2) in non_str_test_cases:
+            ws = self.c.wells_from('A1', 2)
+            ws.set_properties({'property1': val1})
+            ws2 = self.c.wells_from('B1', 2)
+            ws2.set_properties({'property1': val2})
+            both_ws = ws + ws2
+            prop = both_ws.wells_with('property1')
+            assert(prop == both_ws)
+            prop_and_val = both_ws.wells_with('property1', val2)
+            assert(prop_and_val == ws2)
 
     def test_pop(self):
         ws = self.c.wells_from('A1', 3)


### PR DESCRIPTION
We added support for non-str values in properties as part of PR190.  We did not update `wells_with` and this adds in the missing support.