### PR TITLE
Upgrade ApPy to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: python
 python:
-    - "2.7"
     - "3.5"
+    - "3.6"
+    - "3.7"
 install: pip install tox-travis
 script: tox

--- a/autoprotocol/__init__.py
+++ b/autoprotocol/__init__.py
@@ -1,6 +1,6 @@
 from .container import Container, Well, WellGroup  # NOQA
-from .protocol import Protocol  # NOQA
 from .container_type import ContainerType  # NOQA
+from .protocol import Protocol  # NOQA
 from .unit import Unit  # NOQA
 
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -443,6 +443,20 @@ class SPEBuilders(InstructionBuilders):
             amplitude of shaking between 1 and 6:millimeter
         settle_time: bool, optional
             True for orbital and False for linear shaking
+        processing_time: str or Unit
+            Duration for which pressure is applied to the cartridge
+            after `settle_time` has elapsed.
+        flow_pressure: str or Unit
+            Pressure applied to the column.
+        resource_id: str
+            Resource ID of desired solvent.
+        is_sample: bool
+            If a sample is processed.
+        destination_well: Well
+            Destination well for eluate.  Required parameter for
+            each `elute` mobile phase parameter
+        is_elute: bool
+            If an elute is processed.
 
         Returns
         -------

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1,7 +1,7 @@
 """Builders
 Module containing builders, which help build inputs for Instruction parameters
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
@@ -25,18 +25,15 @@ Instruction
 """
 
 from collections import defaultdict
-from functools import reduce
-from sys import version_info
 from numbers import Number
+
+from collections.abc import Iterable  # pylint: disable=no-name-in-module
+from functools import reduce
+
 from .constants import SBS_FORMAT_SHAPES
-from .util import parse_unit, is_valid_well
 from .container import WellGroup, Well, Container
 from .unit import Unit
-
-if version_info.major == 3 and version_info.minor >= 3:
-    from collections.abc import Iterable  # pylint: disable=no-name-in-module
-else:
-    from collections import Iterable  # pylint: disable=no-name-in-module
+from .util import parse_unit, is_valid_well
 
 
 class InstructionBuilders(object):  # pylint: disable=too-few-public-methods

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1,22 +1,17 @@
 """
 Container, Well, WellGroup objects and associated functions
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
-from __future__ import print_function, division
-import warnings
 import json
-import sys
+import warnings
+
 from .constants import SBS_FORMAT_SHAPES
 from .unit import Unit
-
-if sys.version_info.major == 3:
-    xrange = range  # pylint: disable=invalid-name
-    basestring = str  # pylint: disable=invalid-name
 
 SEAL_TYPES = ["ultra-clear", "foil", "breathable"]
 COVER_TYPES = ["standard", "low_evaporation", "universal"]
@@ -53,7 +48,7 @@ class Well(object):
                 "they should be a `dict`.".format(
                     properties, type(properties)))
         for key, value in properties.items():
-            if not isinstance(key, basestring):
+            if not isinstance(key, str):
                 raise TypeError(
                     "Aliquot property {} : {} has a key of type {}, "
                     "it should be a 'str'.".format(key, value, type(key)))
@@ -144,7 +139,7 @@ class Well(object):
         ValueError
             Volume set exceeds maximum well volume
         """
-        if not isinstance(vol, basestring) and not isinstance(vol, Unit):
+        if not isinstance(vol, str) and not isinstance(vol, Unit):
             raise TypeError(
                 "Volume {} is of type {}, it should be either 'str' or 'Unit'."
                 "".format(vol, type(vol)))
@@ -606,7 +601,7 @@ class Container(object):
         self.storage = storage
         self.cover = cover
         self._wells = [Well(self, idx)
-                       for idx in xrange(container_type.well_count)]
+                       for idx in range(container_type.well_count)]
         if self.cover and not (self.is_covered() or self.is_sealed()):
             raise AttributeError("%s is not a valid seal or cover "
                                  "type." % cover)
@@ -632,7 +627,7 @@ class Container(object):
         TypeError
             index given is not of the right type
         """
-        if not isinstance(i, (int, basestring)):
+        if not isinstance(i, (int, str)):
             raise TypeError("Well reference given is not of type 'int' or "
                             "'str'.")
         return self._wells[self.robotize(i)]
@@ -711,7 +706,7 @@ class Container(object):
             else:
                 wells.extend([a])
         for w in wells:
-            if not isinstance(w, (basestring, int, list)):
+            if not isinstance(w, (str, int, list)):
                 raise TypeError("Well reference given is not of type"
                                 " 'int', 'str' or 'list'.")
 
@@ -726,7 +721,7 @@ class Container(object):
         `ContainerType.robotize()` for more information.
 
         """
-        if not isinstance(well_ref, (basestring, int, Well, list)):
+        if not isinstance(well_ref, (str, int, Well, list)):
             raise TypeError("Well reference given is not of type 'str' "
                             "'int', 'Well' or 'list'.")
         return self.container_type.robotize(well_ref)
@@ -740,7 +735,7 @@ class Container(object):
         `ContainerType.humanize()` for more information.
 
         """
-        if not isinstance(well_ref, (int, basestring, list)):
+        if not isinstance(well_ref, (int, str, list)):
             raise TypeError("Well reference given is not of type 'int',"
                             "'str' or 'list'.")
         return self.container_type.humanize(well_ref)
@@ -754,7 +749,7 @@ class Container(object):
         `ContainerType.decompose()` for more information.
 
         """
-        if not isinstance(well_ref, (int, basestring, Well)):
+        if not isinstance(well_ref, (int, str, Well)):
             raise TypeError("Well reference given is not of type 'int', "
                             "'str' or Well.")
         return self.container_type.decompose(well_ref)
@@ -779,8 +774,8 @@ class Container(object):
             num_cols = self.container_type.col_count
             num_rows = self.container_type.well_count // num_cols
             return WellGroup([self._wells[row * num_cols + col]
-                              for col in xrange(num_cols)
-                              for row in xrange(num_rows)])
+                              for col in range(num_cols)
+                              for row in range(num_rows)])
         else:
             return WellGroup(self._wells)
 
@@ -805,15 +800,15 @@ class Container(object):
         num_rows = self.container_type.row_count()
         inner_wells = []
         if columnwise:
-            for c in xrange(1, num_cols - 1):
+            for c in range(1, num_cols - 1):
                 wells = []
-                for r in xrange(1, num_rows - 1):
+                for r in range(1, num_rows - 1):
                     wells.append((r * num_cols) + c)
                 inner_wells.extend(wells)
         else:
             well = num_cols
-            for _ in xrange(1, num_rows - 1):
-                inner_wells.extend(xrange(well + 1, well + (num_cols - 1)))
+            for _ in range(1, num_rows - 1):
+                inner_wells.extend(range(well + 1, well + (num_cols - 1)))
                 well += num_cols
         inner_wells = [self._wells[x] for x in inner_wells]
         return WellGroup(inner_wells)
@@ -846,7 +841,7 @@ class Container(object):
         TypeError
             Incorrect input types, e.g. `num` has to be of type int
         """
-        if not isinstance(start, (basestring, int, Well)):
+        if not isinstance(start, (str, int, Well)):
             raise TypeError("Well reference given is not of type 'str',"
                             "'int', or 'Well'.")
         if not isinstance(num, int):
@@ -929,8 +924,8 @@ class Container(object):
         start_well = [0, 1, 24, 25]
         wells = []
 
-        for row_offset in xrange(start_well[quad], 384, 48):
-            for col_offset in xrange(0, 24, 2):
+        for row_offset in range(start_well[quad], 384, 48):
+            for col_offset in range(0, 24, 2):
                 wells.append(row_offset + col_offset)
 
         return self.wells(wells)
@@ -956,7 +951,7 @@ class Container(object):
             If storage condition not of type str.
 
         """
-        if not isinstance(storage, basestring):
+        if not isinstance(storage, str):
             raise TypeError("Storage condition given ({0}) is not of type "
                             "str. {1}.".format(storage, type(storage)))
 

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -1,21 +1,18 @@
 """
 Container-type object and associated functions
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
-import re
-import sys
 from collections import namedtuple
+
+import re
+
 from .container import Well
 from .unit import Unit
-
-if sys.version_info.major == 3:
-    xrange = range  # pylint: disable=invalid-name
-    basestring = str  # pylint: disable=invalid-name
 
 
 class ContainerType(namedtuple("ContainerType",
@@ -183,7 +180,7 @@ class ContainerType(namedtuple("ContainerType",
         if isinstance(well_ref, list):
             return [self.robotize(well) for well in well_ref]
 
-        if not isinstance(well_ref, (basestring, int, Well)):
+        if not isinstance(well_ref, (str, int, Well)):
             raise TypeError("ContainerType.robotize(): Well reference (%s) "
                             "given is not of type 'str', 'int', or "
                             "'Well'." % well_ref)
@@ -250,7 +247,7 @@ class ContainerType(namedtuple("ContainerType",
         if isinstance(well_ref, list):
             return [self.humanize(well) for well in well_ref]
 
-        if not isinstance(well_ref, (int, basestring)):
+        if not isinstance(well_ref, (int, str)):
             raise TypeError("ContainerType.humanize(): Well reference given "
                             "is not of type 'int' or 'str'.")
         try:
@@ -286,7 +283,7 @@ class ContainerType(namedtuple("ContainerType",
             Index given is not of the right parameter type
 
         """
-        if not isinstance(idx, (int, basestring, Well)):
+        if not isinstance(idx, (int, str, Well)):
             raise TypeError("Well index given is not of type 'int' or "
                             "'str'.")
         idx = self.robotize(idx)

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -1,24 +1,21 @@
 """
 Module containing the harness module which helps with Manifest interpretation
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
-from __future__ import print_function
 import json
+
+import argparse
 import io
+
+from . import UserError
+from .container import WellGroup
 from .protocol import Protocol
 from .unit import Unit, UnitError
-from .container import WellGroup
-from . import UserError
-import argparse
-import sys
-
-if sys.version_info.major == 3:
-    basestring = str  # pylint: disable=invalid-name
 
 _DYE_TEST_RS = {
     "dye4000": "rs18qmhr7t9jwq",
@@ -102,7 +99,7 @@ def get_protocol_preview(protocol, name, manifest='manifest.json'):
 
 
 def param_default(type_desc):
-    if isinstance(type_desc, basestring):
+    if isinstance(type_desc, str):
         type_desc = {'type': type_desc}
 
     type = type_desc['type']  # pylint: disable=redefined-builtin
@@ -179,7 +176,7 @@ def convert_param(protocol, val, type_desc):
         Unknown input type provided
 
     """
-    if isinstance(type_desc, basestring):
+    if isinstance(type_desc, str):
         type_desc = {'type': type_desc}
     if val is None:
         val = param_default(type_desc)

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1268,12 +1268,13 @@ class Image(Instruction):
     exposure : dict, optional
         Parameters to control exposure: "aperture", "iso",
         and "shutter_speed".
-    shutter_speed: Unit, optional
-        Duration that the imaging sensor is exposed.
-    iso : Float, optional
-        Light sensitivity of the imaging sensor.
-    aperture: Float, optional
-        Diameter of the lens opening.
+
+        shutter_speed: Unit, optional
+            Duration that the imaging sensor is exposed.
+        iso : Float, optional
+            Light sensitivity of the imaging sensor.
+        aperture: Float, optional
+            Diameter of the lens opening.
 
     """
 
@@ -1394,38 +1395,38 @@ class SPE(Instruction):
     load_sample: dict
         Parameters for applying the sample to the cartridge.
         Single 'mobile_phase_param'.
-    elute:list of dicts
+    elute: list(dict)
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
         Requires `destination_well`.
-    condition: list of dicts, optional
+    condition: list(dict), optional
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
-    equilibrate: list of dicts, optional
+    equilibrate: list(dict)), optional
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
-    rinse: list of dicts, optional
+    rinse: list(dict), optional
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
 
-    mobile_phase_params:
-    resource_id: str
-        Resource ID of desired solvent.
-    volume: volume
-        Volume added to the cartridge.
-    loading_flowrate: Unit
-        Speed at which volume is added to cartridge.
-    settle_time: Unit
-        Duration for which the solvent remains on the cartridge
-        before a pressure mode is applied.
-    processing_time: Unit
-        Duration for which pressure is applied to the cartridge
-        after `settle_time` has elapsed.
-    flow_pressure: Unit
-        Pressure applied to the column.
-    destination_well: Well
-        Destination well for eluate.  Required parameter for
-        each `elute` mobile phase parameter
+        mobile_phase_params:
+            resource_id: str
+                Resource ID of desired solvent.
+            volume: volume
+                Volume added to the cartridge.
+            loading_flowrate: Unit
+                Speed at which volume is added to cartridge.
+            settle_time: Unit
+                Duration for which the solvent remains on the cartridge
+                before a pressure mode is applied.
+            processing_time: Unit
+                Duration for which pressure is applied to the cartridge
+                after `settle_time` has elapsed.
+            flow_pressure: Unit
+                Pressure applied to the column.
+            destination_well: Well
+                Destination well for eluate.  Required parameter for
+                each `elute` mobile phase parameter
 
     """
     builders = SPEBuilders()
@@ -1481,7 +1482,7 @@ class Sonicate(Instruction):
 
     Parameters
     ----------
-    wells : Well, WellGroup, List of Wells
+    wells : Well or WellGroup or list(Well)
        Wells to be sonicated
     duration : Unit or str
         Duration for which to sonicate wells

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1,7 +1,7 @@
 """
 Contains all the Autoprotocol Instruction objects
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1402,7 +1402,7 @@ class SPE(Instruction):
     condition: list(dict), optional
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
-    equilibrate: list(dict)), optional
+    equilibrate: list(dict), optional
         Parameters for applying a mobile phase to the cartridge
         with one or more solvents. List of 'mobile_phase_params'.
     rinse: list(dict), optional

--- a/autoprotocol/liquid_handle/__init__.py
+++ b/autoprotocol/liquid_handle/__init__.py
@@ -2,7 +2,7 @@
 Liquid handling utilities and methods utilized by Protocol.transfer to
 generate LiquidHandle instructions.
 """
-from .liquid_handle_method import LiquidHandleMethod
 from .liquid_class import LiquidClass
-from .transfer import *
+from .liquid_handle_method import LiquidHandleMethod
 from .mix import *
+from .transfer import *

--- a/autoprotocol/liquid_handle/liquid_class.py
+++ b/autoprotocol/liquid_handle/liquid_class.py
@@ -3,8 +3,9 @@
 Base class for defining the portions of liquid handling behavior that are
 intrinsic to specific types of liquids.
 """
-from numbers import Number
 from collections import namedtuple
+from numbers import Number
+
 from ..util import parse_unit
 
 

--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -18,8 +18,8 @@ supports.
 """
 from .tip_type import TipType
 from ..instruction import LiquidHandle
-from ..util import parse_unit
 from ..unit import Unit
+from ..util import parse_unit
 
 
 # pylint: disable=too-many-public-methods,protected-access

--- a/autoprotocol/liquid_handle/mix.py
+++ b/autoprotocol/liquid_handle/mix.py
@@ -5,8 +5,8 @@ movements within individual wells.
 """
 from .transfer import LiquidHandleMethod
 from ..instruction import LiquidHandle
-from ..util import parse_unit
 from ..unit import Unit
+from ..util import parse_unit
 
 
 # pylint: disable=protected-access

--- a/autoprotocol/liquid_handle/tip_type.py
+++ b/autoprotocol/liquid_handle/tip_type.py
@@ -2,6 +2,7 @@
 Generic tip type and device class mappings for LiquidHandleMethods
 """
 from collections import namedtuple
+
 from autoprotocol.util import parse_unit
 
 

--- a/autoprotocol/liquid_handle/tip_type.py
+++ b/autoprotocol/liquid_handle/tip_type.py
@@ -3,7 +3,7 @@ Generic tip type and device class mappings for LiquidHandleMethods
 """
 from collections import namedtuple
 
-from autoprotocol.util import parse_unit
+from ..util import parse_unit
 
 
 class TipType(namedtuple("TipType", ["name", "volume"])):

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -4,9 +4,9 @@ Base LiquidHandleMethod used by Protocol.transfer to generate a series of
 movements between pairs of wells.
 """
 from .liquid_handle_method import LiquidHandleMethod
+from ..instruction import LiquidHandle
 from ..unit import Unit
 from ..util import parse_unit
-from ..instruction import LiquidHandle
 
 
 # pylint: disable=unused-argument,too-many-instance-attributes,protected-access

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5321,7 +5321,7 @@ class Protocol(object):
         load_sample: dict
             Parameters for applying the sample to the cartridge.
             Single 'mobile_phase_param'.
-        elute: list(dict))
+        elute: list(dict)
             Parameters for applying a mobile phase to the cartridge
             with one or more solvents. List of 'mobile_phase_params'.
             Requires `destination_well`.

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -2069,6 +2069,7 @@ class Protocol(object):
         Example Usage:
 
         .. code-block:: python
+
             p = Protocol()
             plate = p.ref("test pcr plate", id=None, cont_type="96-pcr",
                           storage="cold_4")
@@ -2083,6 +2084,7 @@ class Protocol(object):
         Autoprotocol Output:
 
         .. code-block:: none
+
             "instructions" : [
                 {
                     "object": "test pcr plate",
@@ -5084,23 +5086,21 @@ class Protocol(object):
 
         .. code-block:: json
 
-            "instructions": [
-                {
-                    "wells": ["sample_plate/0", "sample_plate/1"],
-                    "mode": "bath",
-                    "duration": "1:minute",
-                    "temperature": "ambient",
-                    "frequency": "40:kilohertz"
-                    "mode_params": {
-                        "sample_holder": "suspender"
-                    }
-                    "op": "sonicate"
+            {
+                "op": "sonicate",
+                "wells": ["sample_plate/0", "sample_plate/1"],
+                "mode": "bath",
+                "duration": "1:minute",
+                "temperature": "ambient",
+                "frequency": "40:kilohertz"
+                "mode_params": {
+                    "sample_holder": "suspender"
                 }
-            ]
+            }
 
         Parameters
         ----------
-        wells : Well, WellGroup, List of Wells
+        wells : Well or WellGroup or list(Well)
            Wells to be sonicated
         duration : Unit or str
             Duration for which to sonicate wells
@@ -5119,26 +5119,27 @@ class Protocol(object):
         mode_params: Dict
             Dictionary containing mode parameters for the specified mode.
 
-        .. code-block:: json
-            {
-                "mode": "bath",
-                "mode_params":
-                    {
-                        "sample_holder": Enum({"suspender",
-                                               "perforated_container",
-                                               "solid_container"})
-                        "power": Unit or str, optional
-                    }
-            }
-            - or -
-            {
-                "mode": "horn",
-                "mode_params":
-                    {
-                        "duty_cycle": Float, 0 < value <=1
-                        "amplitude": Unit or str
-                    }
-            }
+            .. code-block:: none
+
+                {
+                    "mode": "bath",
+                    "mode_params":
+                        {
+                            "sample_holder": Enum({"suspender",
+                                                   "perforated_container",
+                                                   "solid_container"})
+                            "power": Unit or str, optional
+                        }
+                }
+                - or -
+                {
+                    "mode": "horn",
+                    "mode_params":
+                        {
+                            "duty_cycle": Float, 0 < value <=1
+                            "amplitude": Unit or str
+                        }
+                }
 
 
         Returns
@@ -5320,38 +5321,38 @@ class Protocol(object):
         load_sample: dict
             Parameters for applying the sample to the cartridge.
             Single 'mobile_phase_param'.
-        elute:list of dicts
+        elute: list(dict))
             Parameters for applying a mobile phase to the cartridge
             with one or more solvents. List of 'mobile_phase_params'.
             Requires `destination_well`.
-        condition: list of dicts, optional
+        condition: list(dict), optional
             Parameters for applying a mobile phase to the cartridge
             with one or more solvents. List of 'mobile_phase_params'.
-        equilibrate: list of dicts, optional
+        equilibrate: list(dict), optional
             Parameters for applying a mobile phase to the cartridge
             with one or more solvents. List of 'mobile_phase_params'.
-        rinse: list of dicts, optional
+        rinse: list(dict), optional
             Parameters for applying a mobile phase to the cartridge
             with one or more solvents. List of 'mobile_phase_params'.
 
-        mobile_phase_params:
-        resource_id: str
-            Resource ID of desired solvent.
-        volume: volume
-            Volume added to the cartridge.
-        loading_flowrate: Unit
-            Speed at which volume is added to cartridge.
-        settle_time: Unit
-            Duration for which the solvent remains on the cartridge
-            before a pressure mode is applied.
-        processing_time: Unit
-            Duration for which pressure is applied to the cartridge
-            after `settle_time` has elapsed.
-        flow_pressure: Unit
-            Pressure applied to the column.
-        destination_well: Well
-            Destination well for eluate.  Required parameter for
-            each `elute` mobile phase parameter
+            mobile_phase_params:
+                resource_id: str
+                    Resource ID of desired solvent.
+                volume: volume
+                    Volume added to the cartridge.
+                loading_flowrate: Unit
+                    Speed at which volume is added to cartridge.
+                settle_time: Unit
+                    Duration for which the solvent remains on the cartridge
+                    before a pressure mode is applied.
+                processing_time: Unit
+                    Duration for which pressure is applied to the cartridge
+                    after `settle_time` has elapsed.
+                flow_pressure: Unit
+                    Pressure applied to the column.
+                destination_well: Well
+                    Destination well for eluate.  Required parameter for
+                    each `elute` mobile phase parameter
 
         Returns
         -------
@@ -5471,12 +5472,13 @@ class Protocol(object):
         exposure : dict, optional
             Parameters to control exposure: "aperture", "iso",
             and "shutter_speed".
-        shutter_speed: Unit, optional
-            Duration that the imaging sensor is exposed.
-        iso : Float, optional
-            Light sensitivity of the imaging sensor.
-        aperture: Float, optional
-            Diameter of the lens opening.
+
+            shutter_speed: Unit, optional
+                Duration that the imaging sensor is exposed.
+            iso : Float, optional
+                Light sensitivity of the imaging sensor.
+            aperture: Float, optional
+                Diameter of the lens opening.
 
 
         Returns
@@ -5485,6 +5487,12 @@ class Protocol(object):
             Returns the :py:class:`autoprotocol.instruction.Image`
             instruction created from the specified parameters
 
+        Raises
+        ------
+        TypeError
+            Invalid input types, e.g. num_images is not a positive integer
+        ValueError
+            Invalid exposure parameter supplied
         """
         valid_image_modes = ["top", "bottom", "side"]
         if not isinstance(ref, Container):
@@ -7086,20 +7094,18 @@ class Protocol(object):
 
         .. code-block:: json
 
-            "instructions": [
-                {
-                    "ref": "container",
-                    "mode": "blowdown",
-                    "duration": "10:minute",
-                    "evaporator_temperature": "22:degC",
-                    "mode_params": {
-                        "gas": "ntirogen",
-                        "vortex_speed": "200:rpm",
-                        "blow_rate": "200:uL/sec"
-                    }
-                    "op": "evaporate"
+            {
+                "op": "evaporate",
+                "ref": "container",
+                "mode": "blowdown",
+                "duration": "10:minute",
+                "evaporator_temperature": "22:degC",
+                "mode_params": {
+                    "gas": "ntirogen",
+                    "vortex_speed": "200:rpm",
+                    "blow_rate": "200:uL/sec"
                 }
-            ]
+            }
 
         Parameters
         ----------

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1,28 +1,21 @@
 """
 Module containing the main `Protocol` object and associated functions
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
+import warnings
+
+from .constants import AGAR_CLLD_THRESHOLD, SPREAD_PATH
 from .container import Container, Well, SEAL_TYPES, COVER_TYPES
 from .container_type import ContainerType, _CONTAINER_TYPES
-from .constants import AGAR_CLLD_THRESHOLD, SPREAD_PATH
+from .instruction import *  # pylint: disable=unused-wildcard-import
 from .liquid_handle import Transfer, Mix, LiquidClass
 from .unit import Unit, UnitError
 from .util import _validate_as_instance, _check_container_type_with_shape
-from .instruction import *  # pylint: disable=unused-wildcard-import
-
-from builtins import round  # pylint: disable=redefined-builtin
-from numbers import Number
-import sys
-import warnings
-
-if sys.version_info.major == 3:
-    xrange = range
-    basestring = str
 
 
 class Ref(object):
@@ -1091,7 +1084,7 @@ class Protocol(object):
                 )
 
         # Auto-generate list from single volume, check if list length matches
-        if isinstance(volume, basestring) or isinstance(volume, Unit):
+        if isinstance(volume, str) or isinstance(volume, Unit):
             if len_dest == 1 and not one_source:
                 volume = [Unit(volume).to("ul")] * len_source
             else:
@@ -1782,7 +1775,7 @@ class Protocol(object):
 
             reagent, resource_id, reagent_source = None, None, reagent
         else:
-            if not isinstance(reagent, basestring):
+            if not isinstance(reagent, str):
                 raise TypeError(
                     "reagent: {} must be a Well or string but it was: {}."
                     "".format(reagent, type(reagent)))
@@ -4966,7 +4959,7 @@ class Protocol(object):
             raise TypeError("Destinations (dests) must be of type Well, "
                             "list of Wells, or WellGroup.")
         dests = WellGroup(dests)
-        if not isinstance(resource_id, basestring):
+        if not isinstance(resource_id, str):
             raise TypeError("Resource ID must be a string.")
         if not isinstance(volumes, list):
             volumes = [Unit(volumes)] * len(dests)
@@ -4978,7 +4971,7 @@ class Protocol(object):
                                    "destinations in length and in order.")
             volumes = [Unit(v) for v in volumes]
         for v in volumes:
-            if not isinstance(v, (basestring, Unit)):
+            if not isinstance(v, (str, Unit)):
                 raise TypeError("Volume must be a string or Unit.")
         for d, v in zip(dests, volumes):
             d_max_vol = d.container.container_type.true_max_vol_ul

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -1,25 +1,21 @@
 """
 Module containing a Units library
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
-from __future__ import division, print_function
+from collections import defaultdict
+from decimal import Decimal, InvalidOperation
+from numbers import Number
+
+from math import ceil, floor
 from pint import UnitRegistry
+from pint.errors import UndefinedUnitError
 from pint.quantity import _Quantity
 from pint.util import UnitsContainer
-from pint.errors import UndefinedUnitError
-from decimal import Decimal, InvalidOperation
-from collections import defaultdict
-from math import ceil, floor
-from numbers import Number
-import sys
-
-if sys.version_info.major == 3:
-    basestring = str  # pylint: disable=invalid-name
 
 
 def to_decimal(number):
@@ -191,7 +187,7 @@ class Unit(_Quantity):
             return value
 
         # Automatically parse String if no units provided
-        if not units and isinstance(value, basestring):
+        if not units and isinstance(value, str):
             try:
                 value, units = value.split(":")
             except ValueError:

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -1,13 +1,12 @@
 """
 Module containing utility functions
 
-    :copyright: 2018 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2019 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 
 """
 
-from __future__ import division
 from .constants import SBS_FORMAT_SHAPES
 from .unit import Unit, UnitStringError, UnitValueError
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Deprecate support for Python 2, migrate to support only Python >=3.5
 * :support:`205` Fix changelog formatting
 
 * :release:`5.6.0 <2019-08-18>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,5 +23,5 @@ Search the Docs
 * :ref:`genindex`
 * :ref:`search`
 
-:copyright: 2018 by The Autoprotocol Development Team, see AUTHORS for more details.
+:copyright: 2019 by The Autoprotocol Development Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,79 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+import sys
+
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+# Load version
 exec(open('autoprotocol/version.py').read())  # pylint: disable=exec-used
+
+# Test Runner (reference: https://docs.pytest.org/en/latest/goodpractices.html)
+class PyTest(TestCommand):
+    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = "--cov=autoprotocol --cov-report=term"
+
+    def run_tests(self):
+        import shlex
+
+         # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
+# Test and Documentation dependencies
+test_deps = [
+    'coverage==4.*',
+    'pylint==1.*',
+    'pytest==4.*',
+    'pytest-cov==2.*',
+    'tox==3.*'
+]
+
+doc_deps = [
+    'releases==1.*',
+    'Sphinx==1.7.*',
+    'sphinx_rtd_theme==0.*'
+]
+
 
 setup(
     name='autoprotocol',
-    url='http://github.com/autoprotocol/autoprotocol-python',
+    url='https://github.com/autoprotocol/autoprotocol-python',
     maintainer='The Autoprotocol Development Team',
     description='Python library for generating Autoprotocol',
     license='BSD',
     maintainer_email="autoprotocol-curators@transcriptic.com",
     version=__version__,  # pylint: disable=undefined-variable
-    test_suite='test',
     install_requires=[
-        'Pint==0.8.1',
-        'future==0.16.0'
+        'Pint==0.8.1'
     ],
-    tests_require=[
-        'coverage==4.*',
-        'pylint==1.*',
-        'pytest==4.*',
-        'tox==3.*'
-    ],
+    python_requires='>=3.5',
+    tests_require=test_deps,
     extras_require={
-        "docs": [
-            "Sphinx==1.*",
-            "sphinx-rtd-theme",
-            "releases"
-        ]
+        'docs': doc_deps,
+        'test': test_deps
     },
+    cmdclass={'pytest': PyTest},
     packages=[
         'autoprotocol',
         'autoprotocol.liquid_handle'
+    ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: Unix',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Software Development',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,17 @@ class PyTest(TestCommand):
 
 # Test and Documentation dependencies
 test_deps = [
-    'coverage==4.*',
-    'pylint==1.*',
-    'pytest==4.*',
-    'pytest-cov==2.*',
-    'tox==3.*'
+    'coverage>=4.5, <5',
+    'pylint>=1.9, <2',
+    'pytest>=4, <5',
+    'pytest-cov>=2, <3',
+    'tox>=3.7, <4'
 ]
 
 doc_deps = [
-    'releases==1.*',
-    'Sphinx==1.7.*',
-    'sphinx_rtd_theme==0.*'
+    'releases>=1.5, <2',
+    'Sphinx>=1.7, <1.8',
+    'sphinx_rtd_theme>=0.4, <1'
 ]
 
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -6,7 +6,7 @@ from autoprotocol.container_type import _CONTAINER_TYPES
 from autoprotocol.instruction import (
     Thermocycle, Incubate, Spin, Dispense, GelPurify,
     Fluorescence, Absorbance, Luminescence, Instruction,
-    Evaporate, SPE
+    SPE
 )
 from autoprotocol.protocol import Protocol, Ref
 from autoprotocol.unit import Unit, UnitError

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,28 @@
 [tox]
-envlist = py{27,35},lint,docs
+envlist = clean, py35, py36, py37, stats, lint, docs
 
 [travis]
 python =
-  2.7: py27
-  3.5: py35,lint,docs
+  3.5: clean, py35, stats, lint, docs
+  3.6: py36
+  3.7: py37
 
 [testenv]
-commands =
-    coverage erase
-    coverage run --source autoprotocol -a -m pytest
-    coverage report -m --rcfile={toxinidir}/.coveragerc
-deps =
-    coverage==4.*
-    pytest==4.*
+deps = .[test]
+commands = python setup.py test
 
-[lint:py35]
-deps =
-    pylint==1.*
-    pytest==4.*
+[testenv:clean]
+commands = coverage erase
+
+[testenv:stats]
+commands = coverage report -m --rcfile={toxinidir}/.coveragerc
+
+[testenv:lint]
 ; disabling Refactor, and Convention linting
-commands =
+commands = 
     pylint {toxinidir}/autoprotocol {toxinidir}/test --rcfile={toxinidir}/.pylintrc --disable=R,C
 
-[docs:py35]
+[testenv:py35]
 changedir = docs
-deps =
-    Sphinx==1.*
-    sphinx_rtd_theme
-    releases
-commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+deps = .[docs]
+commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ commands = coverage report -m --rcfile={toxinidir}/.coveragerc
 commands = 
     pylint {toxinidir}/autoprotocol {toxinidir}/test --rcfile={toxinidir}/.pylintrc --disable=R,C
 
-[testenv:py35]
+[testenv:docs]
+python = basepython
 changedir = docs
 deps = .[docs]
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
With Python 2.7 EOL coming at 1 Jan, 2020, we need to upgrade to Python 3.

As part of this breaking diff, we've also decided to only support Python 3.5 upwards, change the underlying test infrastructure, update and pin some dependencies as well as keeping the documentation up-to-date.