### PR TITLE
Bump version to 6.0.0 for release

### DIFF
--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "5.6.0"
+__version__ = "6.0.0"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :feature:`-` Deprecate support for Python 2, migrate to support only Python >=3.5
+* :release:`6.0.0 <2019-08-21>`
+* :support:`206` Deprecate support for Python 2, migrate to support only Python >=3.5
 * :support:`205` Fix changelog formatting
 
 * :release:`5.6.0 <2019-08-18>`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[wheel]
-universal = 1
-
 [aliases]
 test=pytest


### PR DESCRIPTION
Bumping version to 6.0.0 for release. Major version bump since Py3 upgrade breaks previous compatibility. 

Also removing universal flag from wheels, since this is only Python 3 compatible now