### PR TITLE
Correct bath frequency to 40kHz

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5183,7 +5183,7 @@ class Protocol(object):
             if power:
                 parsed_power = parse_unit(power, "power-watt")
                 parsed_mode_params["power"] = parsed_power
-            frequency = frequency or "20:kilohertz"
+            frequency = frequency or "40:kilohertz"
         if mode == "horn":
             valid_mode_params = ["duty_cycle", "amplitude"]
             if not all(k in mode_params for k in valid_mode_params):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug: `209` Fix Sonicate `bath` mode default frequency
+
 * :release:`6.0.0 <2019-08-21>`
 * :support:`206` Deprecate support for Python 2, migrate to support only Python >=3.5
 * :support:`205` Fix changelog formatting

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug: `209` Fix Sonicate `bath` mode default frequency
+* :bug:`209` Fix Sonicate `bath` mode default frequency
 
 * :release:`6.0.0 <2019-08-21>`
 * :support:`206` Deprecate support for Python 2, migrate to support only Python >=3.5

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ test_deps = [
 doc_deps = [
     'releases>=1.5, <2',
     'Sphinx>=1.7, <1.8',
-    'sphinx_rtd_theme>=0.4, <1'
+    'sphinx_rtd_theme>=0.4, <1',
+    'semantic-version==2.6.0'
 ]
 
 


### PR DESCRIPTION
Correcting default `bath` frequency for Sonicate method.
- Change from 20kHz --> 40kHz