### PR TITLE
Add concentration input types

### DIFF
--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -226,7 +226,7 @@ def convert_param(protocol, val, type_desc):
             raise RuntimeError(
                 "The value supplied to input '%s' (type container+) is "
                 "improperly formatted." % label)
-    elif type in ['volume', 'time', 'length', 'frequency']:
+    elif type in ['volume', 'time', 'length', 'frequency', 'concentration(mass)', 'concentration(molar)']:
         try:
             return Unit(val)
         except UnitError as e:

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "6.1.1"
+__version__ = "6.0.1"

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "6.0.1"
+__version__ = "6.1.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature: Add `concentration(molar)` to valid input-types in harness
+* :feature: Add `concentration(mass)` to valid input-types in harness
 * :bug:`216` Fix pytest-cov package dependency
 
 * :release:`6.0.1 <2019-09-11>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-* :feature: Add `concentration(molar)` to valid input-types in harness
-* :feature: Add `concentration(mass)` to valid input-types in harness
+* :feature:`217` Add `concentration(molar)` to valid input-types in harness
+* :feature:`217` Add `concentration(mass)` to valid input-types in harness
 * :bug:`216` Fix pytest-cov package dependency
 
 * :release:`6.0.1 <2019-09-11>`


### PR DESCRIPTION
Adding manifest input types `concentration(mass)` and `concentration(molar)`.