### PR TITLE
Fix well_from_shape bug

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1049,6 +1049,8 @@ class Container(object):
         # coordinates of the tail (bottom right well) should not exceed bounds
         tail_row = well_rows[-1]
         tail_col = well_cols[-1]
+        # tail_row and tail_col are 0-indexed based
+        # container_rows and container_cols are 1-indexed based
         if tail_row + 1 > container_rows or tail_col + 1 > container_cols:
             raise ValueError(
                 "origin: {} with shape: {} exceeds the bounds of "

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1032,32 +1032,28 @@ class Container(object):
         # getting the row and column values for the origin
         origin_row, origin_col = self.decompose(origin)
 
-        # origin coordinates transformed to SBS format space
-        sbs_row = int(origin_row / container_rows * format_rows)
-        sbs_col = int(origin_col / container_cols * format_cols)
-
-        # coordinates of the tail (bottom right well)
-        tail_row = sbs_row + shape["rows"]
-        tail_col = sbs_col + shape["columns"]
-        if tail_row > format_rows or tail_col > format_cols:
-            raise ValueError(
-                "origin: {} with shape: {} exceeds the bounds of "
-                "container: {}".format(origin, shape, self)
-            )
-
         # ratios of container shape to format shape
         row_scaling = container_rows / format_rows
         col_scaling = container_cols / format_cols
 
-        # the 0-indexed coordinates of all wells to be included
-        well_rows = [
-            int(_ * row_scaling)
-            for _ in range(sbs_row, sbs_row + shape["rows"])
-        ]
-        well_cols = [
-            int(_ * col_scaling)
-            for _ in range(sbs_col, sbs_col + shape["columns"])
-        ]
+        # the 0-indexed coordinates of all wells in origin plate to be included
+        well_rows = []
+        well_cols = []
+        for idx in range(shape["rows"]):
+            well_row = int(origin_row + idx * row_scaling)
+            well_rows.append(well_row)
+        for idx in range(shape["columns"]):
+            well_col = int(origin_col + idx * col_scaling)
+            well_cols.append(well_col)
+
+        # coordinates of the tail (bottom right well) should not exceed bounds
+        tail_row = well_rows[-1]
+        tail_col = well_cols[-1]
+        if tail_row + 1 > container_rows or tail_col + 1 > container_cols:
+            raise ValueError(
+                "origin: {} with shape: {} exceeds the bounds of "
+                "container: {}".format(origin, shape, self)
+            )
 
         return WellGroup([
             self.well_from_coordinates(x, y)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`223` Fix `well_from_shape` logic for 384 well plates
 * :feature:`-` Add `warm_35` incubation location
 * :bug:`-` Fix Image autoprotocol parameter
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -372,6 +372,18 @@ class TestAsShapeOrigin(HasDummyContainers):
             dummy_384.wells_from_shape(0, SHAPE(rows=8, columns=12))
             == dummy_384.quadrant(0)
         )
+        assert(
+            dummy_384.wells_from_shape(1, SHAPE(rows=8, columns=12))
+            == dummy_384.quadrant(1)
+        )
+        assert(
+            dummy_384.wells_from_shape(24, SHAPE(rows=8, columns=12))
+            == dummy_384.quadrant(2)
+        )
+        assert(
+            dummy_384.wells_from_shape(25, SHAPE(rows=8, columns=12))
+            == dummy_384.quadrant(3)
+        )
 
     def test_handles_sbs384_shape(self, dummy_384):
         assert(
@@ -399,6 +411,12 @@ class TestAsShapeOrigin(HasDummyContainers):
     def test_fails_out_of_row_range(self, dummy_96):
         with pytest.raises(ValueError):
             dummy_96.wells_from_shape(12, SHAPE(rows=8))
+
+    def test_fails_out_of_range_sbs384(self, dummy_384):
+        with pytest.raises(ValueError):
+            dummy_384.wells_from_shape(3, SHAPE(rows=8, columns=12))
+        with pytest.raises(ValueError):
+            dummy_384.wells_from_shape(26, SHAPE(rows=8, columns=12))
 
     def test_row_reservoirs_by_column(self, dummy_reservoir_row):
         assert(


### PR DESCRIPTION
well_from_shape was not returning correct wells for index beyond one.
For example, for a 384 well with origin well of A2 and shape of 96 well
to select, it should return the 2nd quadrant, however, the current code
returns the 1st quadrant wells. We added failing tests and fixed this bug
by using a new approach for calculating well indices and checking boundaries.