### PR TITLE
Enable extra detection arguments in position_z dict

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1629,16 +1629,16 @@ class LiquidHandleBuilders(InstructionBuilders):
         if fallback is not None:
             fallback = self.position_z(**fallback)
 
+        detection["method"] = method
+        detection["duration"] = duration
+        detection["threshold"] = threshold
+        detection["fallback"] = fallback
+
         return {
             "reference": reference,
             "offset": offset,
             "move_rate": move_rate,
-            "detection": {
-                "method": method,
-                "duration": duration,
-                "threshold": threshold,
-                "fallback": fallback
-            }
+            "detection": detection
         }
 
     @staticmethod

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -122,6 +122,25 @@ class TestLiquidHandleBuilder(object):
             structured_position_z
         )
 
+        extra_detection_arguments_positions_z = {
+            "reference": flat_position_z["reference"],
+            "offset": flat_position_z["offset"],
+            "move_rate": flat_position_z["move_rate"],
+            "detection": {
+                "method": flat_position_z["detection_method"],
+                "threshold": flat_position_z["detection_threshold"],
+                "duration": flat_position_z["detection_duration"],
+                "fallback": flat_position_z["detection_fallback"],
+                "x_edge_steepness": 20,
+                "x_detection_offset": 20
+            }
+        }
+
+        assert(
+            LiquidHandle.builders.position_z(**extra_detection_arguments_positions_z) ==
+            extra_detection_arguments_positions_z
+        )
+
         with pytest.raises(ValueError):
             LiquidHandle.builders.position_z(
                 reference="well_top", detection_method="capacitance"

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -131,8 +131,8 @@ class TestLiquidHandleBuilder(object):
                 "threshold": flat_position_z["detection_threshold"],
                 "duration": flat_position_z["detection_duration"],
                 "fallback": flat_position_z["detection_fallback"],
-                "x_edge_steepness": 20,
-                "x_detection_offset": 20
+                "sensitivity": 20,
+                "offset": 20
             }
         }
 


### PR DESCRIPTION
This PR aims at enabling the passing of extra arguments in the `detection` dictionary within the `position_z` dict of the `LiquidHandleMethod` class.

Such extra arguments can be used to handle capacitive / pressure liquid level detection with liquid handlers that do not support the direct passing of thresholds in pascal or farads such as Hamilton STAR class liquid handlers.

The `LiquidHandle.builders.position_z` input checking method was rigidly sanitizing inputs to the expected arguments and stripping any extra arguments passed in the `detection` dict.