### PR TITLE
Updating LiquidHandle instruction with 'density' parameter and 'positive_displacement' mode

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1305,7 +1305,7 @@ class LiquidHandleBuilders(InstructionBuilders):
             "transports": transports
         }
 
-    def transport(self, volume=None, pump_override_volume=None,
+    def transport(self, volume=None, density=None, pump_override_volume=None,
                   flowrate=None, delay_time=None, mode_params=None):
         """Helper for building transports
 
@@ -1314,6 +1314,8 @@ class LiquidHandleBuilders(InstructionBuilders):
         volume : Unit or str, optional
             Volume to be aspirated/dispensed. Positive volume -> Dispense.
             Negative -> Aspirate
+        density : Unit or str, optional
+            Density of the liquid to be aspirated/dispensed.
         pump_override_volume : Unit or str, optional
             Calibrated volume, volume which the pump will move
         flowrate : dict, optional
@@ -1333,6 +1335,8 @@ class LiquidHandleBuilders(InstructionBuilders):
         """
         if volume is not None:
             volume = parse_unit(volume, "ul")
+        if density is not None:
+            density = parse_unit(density, "mg/ml")
         if pump_override_volume is not None:
             pump_override_volume = parse_unit(pump_override_volume, "ul")
         if flowrate is not None:
@@ -1344,6 +1348,7 @@ class LiquidHandleBuilders(InstructionBuilders):
 
         return {
             "volume": volume,
+            "density": density,
             "pump_override_volume": pump_override_volume,
             "flowrate": flowrate,
             "delay_time": delay_time,

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1846,7 +1846,8 @@ class LiquidHandleBuilders(InstructionBuilders):
             # remove automatically added 'air' class from blowout, etc.
             non_air_classes = [liq for liq in liquid_classes if liq != "air"]
             # if liquid classes only contain "air" type, mode is returned.
-            if not non_air_classes:
+            has_only_air_classes = not non_air_classes
+            if has_only_air_classes:
                 return liquid_class_to_dispense_modes["air"]
 
             modes = []

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1236,7 +1236,7 @@ class SpectrophotometryBuilders(InstructionBuilders):
             return self.position_z_calculated(
                 **position_z["calculated_from_wells"]
             )
-        if "manual" in position_z:
+        elif "manual" in position_z:
             return self.position_z_manual(
                 **position_z["manual"]
             )

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1762,12 +1762,14 @@ class LiquidHandleBuilders(InstructionBuilders):
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
                 flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")),
+                    target=Unit(10, "uL/s")
+                ),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="air",
                     position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position")
+                        reference="preceding_position"
+                    )
                 )
             ),
             LiquidHandle.builders.transport(
@@ -1775,12 +1777,14 @@ class LiquidHandleBuilders(InstructionBuilders):
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
                 flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")),
+                    target=Unit(10, "uL/s")
+                ),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="viscous",
                     position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position")
+                        reference="preceding_position"
+                    )
                 )
             )
         ]

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1877,7 +1877,7 @@ class LiquidHandleBuilders(InstructionBuilders):
             # if liquid class only contains "air" and/or None, default to
             # "air_displacement".
             if not modes:
-                modes.append("air_displacement")
+                modes.append(liquid_class_to_dispense_modes["air"])
             # return error if there are incompatible liquid_class a set of
             # transports.
             if len(set(modes)) > 1:

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1336,17 +1336,17 @@ class LiquidHandleBuilders(InstructionBuilders):
         dict
             transport parameters for a LiquidHandle instruction
         """
-        if volume:
+        if volume is not None:
             volume = parse_unit(volume, "ul")
-        if density:
+        if density is not None:
             density = parse_unit(density, "mg/ml")
-        if pump_override_volume:
+        if pump_override_volume is not None:
             pump_override_volume = parse_unit(pump_override_volume, "ul")
-        if flowrate:
+        if flowrate is not None:
             flowrate = self.flowrate(**flowrate)
-        if delay_time:
+        if delay_time is not None:
             delay_time = parse_unit(delay_time, "s")
-        if mode_params:
+        if mode_params is not None:
             mode_params = self.mode_params(**mode_params)
 
         return {
@@ -1831,10 +1831,6 @@ class LiquidHandleBuilders(InstructionBuilders):
             "viscous": "positive_displacement"
         }
         if mode:
-            if not isinstance(mode, str):
-                raise TypeError(
-                    "mode: {} must be in str".format(mode)
-                )
             if mode not in self.dispense_modes:
                 raise ValueError(
                     "mode: {} must be one of the valid modes: {}"
@@ -1872,7 +1868,12 @@ class LiquidHandleBuilders(InstructionBuilders):
                     )
                 )
             modes.add(liquid_class_to_dispense_mode[other_class])
-
+        # return error if modes is empty.
+        if not modes:
+            raise ValueError(
+                "modes: {} resulted in an empty set. Make sure valid mode is "
+                "added for each liquid class."
+            ).format(modes)
         # return error if there are incompatible liquid_class a set of
         # transports.
         if len(set(modes)) > 1:
@@ -1883,7 +1884,6 @@ class LiquidHandleBuilders(InstructionBuilders):
                 "is allowed per transfer."
                 "".format(set(modes), self.dispense_modes)
             )
-
         return list(modes)[0]
 
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1889,7 +1889,7 @@ class LiquidHandleBuilders(InstructionBuilders):
                     "".format(set(modes), self.dispense_modes)
                 )
 
-            mode = list(modes)[0]
+            mode = modes[0]
 
         return mode
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1810,12 +1810,16 @@ class LiquidHandleBuilders(InstructionBuilders):
 
         Raises
         ------
+        TypeError
+            mode is not in str
         ValueError
             mode does not contain valid mode value
         TypeError
             liquid is not of str
         ValueError
             liquid_class is not a valid value
+        ValueError
+            liquid_class did not resolve to a mode
         ValueError
             multiple liquid_class exists in one LiquidHandle
         """
@@ -1826,6 +1830,10 @@ class LiquidHandleBuilders(InstructionBuilders):
             "viscous": "positive_displacement"
         }
         if mode:
+            if not isinstance(mode, str):
+                raise TypeError(
+                    "mode: {} must be in str".format(mode)
+                )
             if mode not in self.dispense_modes:
                 raise ValueError(
                     "mode: {} must be one of the valid modes: {}"
@@ -1880,8 +1888,8 @@ class LiquidHandleBuilders(InstructionBuilders):
                     "is allowed per transfer."
                     "".format(set(modes), self.dispense_modes)
                 )
-            if len(set(modes)) == 1:
-                mode = list(modes)[0]
+
+            mode = list(modes)[0]
 
         return mode
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1308,8 +1308,8 @@ class LiquidHandleBuilders(InstructionBuilders):
             "transports": transports
         }
 
-    def transport(self, volume=None, pump_override_volume=None, flowrate=None,
-                  delay_time=None, mode_params=None, density=None):
+    def transport(self, volume=None, pump_override_volume=None,
+                  flowrate=None, delay_time=None, mode_params=None, density=None):
         """Helper for building transports
 
         Parameters

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1751,7 +1751,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         For non-viscous, water-like liquid and air, the method will default
         to "air_displacement". To allow for more accurate aspirate and
         dispense volumes, 'viscous' liquid where air pressure alone is
-        sometimes not sufficient to overcome the surface tenstion to pull
+        sometimes not sufficient to overcome the surface tension to pull
         or push the liquid sufficiently through transfer tip, it will
         default to "positive_displacement" unless otherwise specified.
 
@@ -1845,20 +1845,18 @@ class LiquidHandleBuilders(InstructionBuilders):
         # get liquid_classes from transport input
         liquid_classes = set([transport["mode_params"]["liquid_class"]
                               for transport in transports])
-
-        # # remove automatically added 'air' class from blowout, etc.
+        # remove automatically added 'air' (e.g. from blowout steps) and None
+        # classes.
         other_classes = liquid_classes - {"air", None}
-
         if not other_classes:
             return liquid_class_to_dispense_mode["air"]
 
         modes = set()
         for other_class in other_classes:
-
             # resolve mode for different other_class classes (except for None).
             if not isinstance(other_class, str):
                 raise TypeError(
-                    "other_class: {} is not of type str".format(other_class)
+                    "liquid_class: {} is not of type str".format(other_class)
                 )
             if other_class not in self.liquid_classes:
                 raise ValueError(
@@ -1867,7 +1865,7 @@ class LiquidHandleBuilders(InstructionBuilders):
                 )
             if other_class not in liquid_class_to_dispense_mode.keys():
                 raise ValueError(
-                    "other_class: {} did not resolve accordingly. If there "
+                    "liquid_class: {} did not resolve accordingly. If there "
                     "is a new liquid_class, make sure dictionary: {}"
                     "is updated.".format(
                         other_class, liquid_class_to_dispense_mode
@@ -1879,7 +1877,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         # transports.
         if len(set(modes)) > 1:
             raise ValueError(
-                "There are multiple other_class classes which could potentially"
+                "There are multiple liquid_class types which could potentially"
                 "have different modes: {}."
                 "Please specify the mode to be used from: {}. Only one mode"
                 "is allowed per transfer."

--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -320,7 +320,7 @@ class LiquidHandleMethod(object):
     def _aspirate_simple(self, volume, initial_z,
                          position_x=None, position_y=None,
                          calibrated_vol=None, flowrate=None, delay_time=None,
-                         liquid_class=None):
+                         liquid_class=None, density=None):
         """Helper function for generating aspirate transports
 
         Parameters
@@ -341,6 +341,8 @@ class LiquidHandleMethod(object):
             time to pause after aspirating to let pressure equilibrate
         liquid_class : str, optional
             the name of the liquid class being aspirated
+        density : Unit, optional
+            the density of liquid being aspirated
         """
 
         followup_z = self._move_to_initial_position(
@@ -356,6 +358,7 @@ class LiquidHandleMethod(object):
 
         self._transports += [LiquidHandle.builders.transport(
             volume=-volume,
+            density=density,
             # pylint: disable=invalid-unary-operand-type
             pump_override_volume=-calibrated_vol if calibrated_vol else None,
             flowrate=flowrate,
@@ -367,7 +370,7 @@ class LiquidHandleMethod(object):
                              position_x=None, position_y=None,
                              calibrated_vol=None,
                              asp_flowrate=None, dsp_flowrate=None,
-                             delay_time=None, liquid_class=None):
+                             delay_time=None, liquid_class=None, density=None):
         """Helper function for generating aspiration with priming
 
         Parameters
@@ -392,6 +395,8 @@ class LiquidHandleMethod(object):
             time to pause after aspirating to let pressure equilibrate
         liquid_class : str, optional
             the name of the liquid class being aspirated
+        density : Unit, optional
+            the density of liquid being aspirated
         """
 
         followup_z = self._move_to_initial_position(
@@ -409,6 +414,7 @@ class LiquidHandleMethod(object):
         self._transports += [
             LiquidHandle.builders.transport(
                 volume=-prime_vol,
+                density=density,
                 pump_override_volume=-prime_vol,
                 flowrate=asp_flowrate,
                 mode_params=mode_params,
@@ -416,6 +422,7 @@ class LiquidHandleMethod(object):
             ),
             LiquidHandle.builders.transport(
                 volume=-volume,
+                density=density,
                 # pylint: disable=invalid-unary-operand-type
                 pump_override_volume=(
                     -calibrated_vol if calibrated_vol else None
@@ -426,6 +433,7 @@ class LiquidHandleMethod(object):
             ),
             LiquidHandle.builders.transport(
                 volume=prime_vol,
+                density=density,
                 pump_override_volume=prime_vol,
                 flowrate=dsp_flowrate,
                 mode_params=mode_params,
@@ -436,7 +444,7 @@ class LiquidHandleMethod(object):
     def _dispense_simple(self, volume, initial_z,
                          position_x=None, position_y=None,
                          calibrated_vol=None, flowrate=None, delay_time=None,
-                         liquid_class=None):
+                         liquid_class=None, density=None):
         """Helper function for generating dispense transports
 
         Parameters
@@ -457,6 +465,8 @@ class LiquidHandleMethod(object):
             time to pause after dispensing to let pressure equilibrate
         liquid_class : str, optional
             the name of the liquid class being dispensed
+        density : Unit, optional
+            the density of liquid to be dispensed
         """
 
         followup_z = self._move_to_initial_position(
@@ -472,6 +482,7 @@ class LiquidHandleMethod(object):
 
         self._transports += [LiquidHandle.builders.transport(
             volume=volume,
+            density=density,
             pump_override_volume=calibrated_vol if calibrated_vol else None,
             flowrate=flowrate,
             mode_params=mode_params,

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -144,7 +144,7 @@ class Transfer(LiquidHandleMethod):
             flowrate=None
         )
 
-    def _aspirate_transports(self, volume):
+    def _aspirate_transports(self, volume, density):
         """Generates source well transports
 
         Generates and returns all of the transports that should happen within
@@ -182,12 +182,12 @@ class Transfer(LiquidHandleMethod):
 
         self._transport_pre_buffer(volume)
         self._transport_mix_before(volume)
-        self._transport_aspirate_target_volume(volume)
+        self._transport_aspirate_target_volume(volume, density)
         self._transport_aspirate_transit(volume)
 
         return self._transports
 
-    def _dispense_transports(self, volume):
+    def _dispense_transports(self, volume, density):
         """Generates destination well transports
 
         Generates and returns all of the transports that should happen within
@@ -224,7 +224,7 @@ class Transfer(LiquidHandleMethod):
             return []
 
         self._transport_dispense_transit(volume)
-        self._transport_dispense_target_volume(volume)
+        self._transport_dispense_target_volume(volume, density)
         self._transport_mix_after(volume)
         self._transport_blowout(volume)
 
@@ -294,12 +294,13 @@ class Transfer(LiquidHandleMethod):
             )
         )
 
-    def _transport_aspirate_target_volume(self, volume):
+    def _transport_aspirate_target_volume(self, volume, density):
         """Aspirates the target volume from the source location
 
         Parameters
         ----------
         volume : Unit
+        density : Unit
 
         See Also
         --------
@@ -336,7 +337,8 @@ class Transfer(LiquidHandleMethod):
                     volume, self.tip_type
                 ),
                 delay_time=self._source_liquid.delay_time,
-                liquid_class=self._source_liquid.name
+                liquid_class=self._source_liquid.name,
+                density=density
             )
         else:
             self._aspirate_simple(
@@ -349,7 +351,8 @@ class Transfer(LiquidHandleMethod):
                     volume, self.tip_type
                 ),
                 delay_time=self._source_liquid.delay_time,
-                liquid_class=self._source_liquid.name
+                liquid_class=self._source_liquid.name,
+                density=density
             )
 
     def default_aspirate_z(self, volume):
@@ -477,12 +480,13 @@ class Transfer(LiquidHandleMethod):
 
         return transit_vol
 
-    def _transport_dispense_target_volume(self, volume):
+    def _transport_dispense_target_volume(self, volume, density):
         """Dispenses the target volume into the destination location
 
         Parameters
         ----------
         volume : Unit
+        density : Unit
 
         See Also
         --------
@@ -503,7 +507,8 @@ class Transfer(LiquidHandleMethod):
                 volume, self.tip_type
             ),
             delay_time=self._source_liquid.delay_time,
-            liquid_class=self._source_liquid.name
+            liquid_class=self._source_liquid.name,
+            density=density
         )
 
     def default_dispense_z(self, volume):
@@ -625,7 +630,7 @@ class PreMixBlowoutTransfer(Transfer):
         )
         self.pre_mix_blowout = pre_mix_blowout
 
-    def _dispense_transports(self, volume=None):
+    def _dispense_transports(self, volume=None, density=None):
         self._transports = []
         volume = parse_unit(volume, "ul")
 
@@ -634,7 +639,7 @@ class PreMixBlowoutTransfer(Transfer):
             return []
 
         self._transport_dispense_transit(volume)
-        self._transport_dispense_target_volume(volume)
+        self._transport_dispense_target_volume(volume, density)
         self._transport_pre_mix_blowout(volume)
         self._transport_mix_after(volume)
         self._transport_blowout(volume)

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -19,7 +19,6 @@ from .util import _validate_as_instance, _check_container_type_with_shape
 
 
 class Ref(object):
-
     """
     Link a ref name (string) to a Container instance.
 
@@ -287,6 +286,7 @@ class Protocol(object):
         )
         self.refs[name] = Ref(name, opts, container)
         return container
+
     # pragma pylint: enable=redefined-builtin
 
     def add_time_constraint(self, from_dict, to_dict, less_than=None,
@@ -490,8 +490,8 @@ class Protocol(object):
 
         def add_time_constraint_internal(time_const):
             setattr(self, "time_constraints", (
-                getattr(self, "time_constraints", []) + [time_const])
-            )
+                    getattr(self, "time_constraints", []) + [time_const])
+                    )
 
         keys = []
 
@@ -1106,7 +1106,7 @@ class Protocol(object):
             raise RuntimeError(
                 "Transfer volume has to be a multiple of the droplet size ({})."
                 "This is not true for the following volumes: {}"
-                .format(droplet_size, vol_errors)
+                    .format(droplet_size, vol_errors)
             )
         # Ensure enough volume in single well to transfer to all dest wells
         if one_source:
@@ -1363,7 +1363,7 @@ class Protocol(object):
                     "Illumina sequencing lanes must be a list(dict)"
                 )
             if not all(k in l.keys() for k in [
-                    "object", "library_concentration"]):
+                "object", "library_concentration"]):
                 raise TypeError("Each Illumina sequencing lane must contain an "
                                 "'object' and a 'library_concentration'")
             if not isinstance(l["object"], Well):
@@ -1385,7 +1385,7 @@ class Protocol(object):
                              " modes: {}.You specified: {}."
                              "".format(sequencer,
                                        ', '.join(valid_sequencers[
-                                                 sequencer]["modes"]),
+                                                     sequencer]["modes"]),
                                        mode)
                              )
         if index not in valid_indices:
@@ -1533,7 +1533,7 @@ class Protocol(object):
 
         if not isinstance(wells, list):
             raise TypeError("Unknown input. SangerSeq wells accepts either a"
-                             "Well, a WellGroup, or a list of well indices")
+                            "Well, a WellGroup, or a list of well indices")
 
         return self._append_and_return(
             SangerSeq(cont, wells, dataref, type, primer))
@@ -1765,7 +1765,7 @@ class Protocol(object):
 
             # Volume accounting
             total_vol_dispensed = (
-                sum([Unit(c["volume"]) for c in columns]) * row_count)
+                    sum([Unit(c["volume"]) for c in columns]) * row_count)
             if pre_dispense is not None:
                 total_vol_dispensed += nozzle_count * pre_dispense
             if reagent.volume:
@@ -4212,7 +4212,7 @@ class Protocol(object):
                 raise ValueError("Each sample or control must indicate a "
                                  "volume of type unit. %s" % e)
             if (s.get("captured_events") and not
-                    isinstance(s.get("captured_events"), int)):
+            isinstance(s.get("captured_events"), int)):
                 raise TypeError("captured_events is optional, if given it"
                                 " must be of type integer.")
         for c in controls:
@@ -4221,7 +4221,7 @@ class Protocol(object):
                                 "indicating the colors/channels that this"
                                 " control is to be used for.")
             if (c.get("minimize_bleed") and not
-                    isinstance(c.get("minimize_bleed"), list)):
+            isinstance(c.get("minimize_bleed"), list)):
                 raise TypeError("Minimize_bleed must be of type list.")
             elif c.get("minimize_bleed"):
                 for b in c["minimize_bleed"]:
@@ -4275,7 +4275,7 @@ class Protocol(object):
                                         "type dict.")
                     else:
                         if (not c.get("name") or not
-                                isinstance(c.get("name"), str)):
+                        isinstance(c.get("name"), str)):
                             raise TypeError("Each color must have a `name` "
                                             "that is of type string.")
                         if c.get("emission_wavelength"):
@@ -5407,7 +5407,6 @@ class Protocol(object):
             )
         )
 
-
     def image(self, ref, mode, dataref, num_images=1, backlighting=None,
               exposure=None, magnification=1.0):
         """
@@ -5507,7 +5506,7 @@ class Protocol(object):
             raise TypeError("num_images must be a positive integer.")
         if magnification:
             if not isinstance(magnification, (float, int)) or \
-               magnification <= 0:
+                    magnification <= 0:
                 raise TypeError("magnification must be a number.")
         if backlighting:
             if not isinstance(backlighting, bool):
@@ -5599,10 +5598,10 @@ class Protocol(object):
         """
         last_instruction = self.instructions[-1] if self.instructions else None
         maybe_same_instruction = (
-            new_instruction is False and
-            last_instruction and
-            isinstance(last_instruction, MagneticTransfer) and
-            last_instruction.data.get("magnetic_head") == head
+                new_instruction is False and
+                last_instruction and
+                isinstance(last_instruction, MagneticTransfer) and
+                last_instruction.data.get("magnetic_head") == head
         )
         # Overwriting __dict__ since that's edited on __init__ and we use it
         # for downstream checks
@@ -6341,7 +6340,7 @@ class Protocol(object):
     def transfer(self, source, destination, volume, rows=1, columns=1,
                  source_liquid=LiquidClass,
                  destination_liquid=LiquidClass,
-                 method=Transfer, one_tip=False, density=None):
+                 method=Transfer, one_tip=False, density=None, mode=None):
         """Generates LiquidHandle instructions between wells
 
         Transfer liquid between specified pairs of source & destination wells.
@@ -6374,6 +6373,8 @@ class Protocol(object):
             If True then a single tip will be used for all operations
         density : Unit or str, optional
             Density of the liquid to be aspirated/dispensed
+        mode : str, optional
+            The liquid handling mode
 
         Returns
         -------
@@ -6467,6 +6468,7 @@ class Protocol(object):
         --------
         Transfer : base LiquidHandleMethod for transfer operations
         """
+
         def location_helper(source, destination, volume, method, density):
             """Generates LiquidHandle transfer locations
 
@@ -6612,18 +6614,22 @@ class Protocol(object):
         locations, instructions = [], []
         for src, des, vol, met, dens in zip(source, destination, volume, method, density):
             max_tip_capacity = met._tip_capacity()
-
             remaining_vol = vol
             while remaining_vol > Unit(0, "ul"):
                 transfer_vol = min(remaining_vol, max_tip_capacity)
                 if one_tip is True:
                     locations += location_helper(src, des, transfer_vol, met, dens)
                 else:
+                    location_transports = location_helper(src, des, transfer_vol, met, dens)
+                    source_transports = location_transports[0]["transports"]
+                    instruction_mode = mode
+                    if instruction_mode is None:
+                        instruction_mode = LiquidHandle.builders.mode(source_transports, mode)
                     instructions.append(
                         LiquidHandle(
-                            location_helper(src, des, transfer_vol, met, dens),
+                            location_transports,
                             shape=met._shape,
-                            mode="air_displacement",
+                            mode=instruction_mode,
                             mode_params=(
                                 LiquidHandle.builders.instruction_mode_params(
                                     tip_type=met.tip_type
@@ -6635,11 +6641,14 @@ class Protocol(object):
 
         # if one tip is true then there's a locations list
         if locations:
+            source_transports = locations[0]["transports"]
+            if mode is None:
+                mode = LiquidHandle.builders.mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
                     locations,
                     shape=shape,
-                    mode="air_displacement",
+                    mode=mode,
                     mode_params=LiquidHandle.builders.instruction_mode_params(
                         tip_type=method[0].tip_type
                     )
@@ -6649,7 +6658,7 @@ class Protocol(object):
 
     # pylint: disable=protected-access
     def mix(self, well, volume, rows=1, columns=1,
-            liquid=LiquidClass, method=Mix, one_tip=False):
+            liquid=LiquidClass, method=Mix, one_tip=False, mode=None):
         """Generates LiquidHandle instructions within wells
 
         Mix liquid in specified wells.
@@ -6675,6 +6684,8 @@ class Protocol(object):
             define a set of physical movements.
         one_tip : bool, optional
             If True then a single tip will be used for all operations
+        mode : str, optional
+            The liquid handling mode
 
         Returns
         -------
@@ -6751,6 +6762,7 @@ class Protocol(object):
         --------
         Mix : base LiquidHandleMethod for mix operations
         """
+
         def location_helper(aliquot, volume, method):
             """Generates LiquidHandle mix locations
 
@@ -6859,11 +6871,16 @@ class Protocol(object):
             if one_tip is True:
                 locations += location_helper(wel, vol, met)
             else:
+                location_transports = location_helper(wel, vol, met)
+                source_transports = location_transports[0]["transports"]
+                instruction_mode = mode
+                if instruction_mode is None:
+                    instruction_mode = LiquidHandle.builders.mode(source_transports, mode)
                 instructions.append(
                     LiquidHandle(
-                        location_helper(wel, vol, met),
+                        location_transports,
                         shape=met._shape,
-                        mode="air_displacement",
+                        mode=instruction_mode,
                         mode_params=(
                             LiquidHandle.builders.instruction_mode_params(
                                 tip_type=met.tip_type
@@ -6874,11 +6891,14 @@ class Protocol(object):
 
         # if one tip is true then there's a locations list
         if locations:
+            source_transports = locations[0]["transports"]
+            if mode is None:
+                mode = LiquidHandle.builders.mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
                     locations,
                     shape=shape,
-                    mode="air_displacement",
+                    mode=mode,
                     mode_params=LiquidHandle.builders.instruction_mode_params(
                         tip_type=method[0].tip_type
                     )
@@ -6928,6 +6948,7 @@ class Protocol(object):
         TypeError
             If specified destination is not of type Well
         """
+
         def euclidean_distance(point_a, point_b):
             """
             Calculate the euclidean distance between a pair of xy coordinates

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -6624,7 +6624,7 @@ class Protocol(object):
                     source_transports = location_transports[0]["transports"]
                     instruction_mode = mode
                     if instruction_mode is None:
-                        instruction_mode = LiquidHandle.builders.mode(source_transports, mode)
+                        instruction_mode = LiquidHandle.builders.desired_mode(source_transports, mode)
                     instructions.append(
                         LiquidHandle(
                             location_transports,
@@ -6643,7 +6643,7 @@ class Protocol(object):
         if locations:
             source_transports = locations[0]["transports"]
             if mode is None:
-                mode = LiquidHandle.builders.mode(source_transports, mode)
+                mode = LiquidHandle.builders.desired_mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
                     locations,
@@ -6875,7 +6875,7 @@ class Protocol(object):
                 source_transports = location_transports[0]["transports"]
                 instruction_mode = mode
                 if instruction_mode is None:
-                    instruction_mode = LiquidHandle.builders.mode(source_transports, mode)
+                    instruction_mode = LiquidHandle.builders.desired_mode(source_transports, mode)
                 instructions.append(
                     LiquidHandle(
                         location_transports,
@@ -6893,7 +6893,7 @@ class Protocol(object):
         if locations:
             source_transports = locations[0]["transports"]
             if mode is None:
-                mode = LiquidHandle.builders.mode(source_transports, mode)
+                mode = LiquidHandle.builders.desired_mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
                     locations,

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -19,6 +19,7 @@ from .util import _validate_as_instance, _check_container_type_with_shape
 
 
 class Ref(object):
+
     """
     Link a ref name (string) to a Container instance.
 
@@ -286,7 +287,6 @@ class Protocol(object):
         )
         self.refs[name] = Ref(name, opts, container)
         return container
-
     # pragma pylint: enable=redefined-builtin
 
     def add_time_constraint(self, from_dict, to_dict, less_than=None,
@@ -490,8 +490,8 @@ class Protocol(object):
 
         def add_time_constraint_internal(time_const):
             setattr(self, "time_constraints", (
-                    getattr(self, "time_constraints", []) + [time_const])
-                    )
+                getattr(self, "time_constraints", []) + [time_const])
+            )
 
         keys = []
 
@@ -1106,7 +1106,7 @@ class Protocol(object):
             raise RuntimeError(
                 "Transfer volume has to be a multiple of the droplet size ({})."
                 "This is not true for the following volumes: {}"
-                    .format(droplet_size, vol_errors)
+                .format(droplet_size, vol_errors)
             )
         # Ensure enough volume in single well to transfer to all dest wells
         if one_source:
@@ -1363,7 +1363,7 @@ class Protocol(object):
                     "Illumina sequencing lanes must be a list(dict)"
                 )
             if not all(k in l.keys() for k in [
-                "object", "library_concentration"]):
+                    "object", "library_concentration"]):
                 raise TypeError("Each Illumina sequencing lane must contain an "
                                 "'object' and a 'library_concentration'")
             if not isinstance(l["object"], Well):
@@ -1385,7 +1385,7 @@ class Protocol(object):
                              " modes: {}.You specified: {}."
                              "".format(sequencer,
                                        ', '.join(valid_sequencers[
-                                                     sequencer]["modes"]),
+                                                sequencer]["modes"]),
                                        mode)
                              )
         if index not in valid_indices:
@@ -1765,7 +1765,7 @@ class Protocol(object):
 
             # Volume accounting
             total_vol_dispensed = (
-                    sum([Unit(c["volume"]) for c in columns]) * row_count)
+                sum([Unit(c["volume"]) for c in columns]) * row_count)
             if pre_dispense is not None:
                 total_vol_dispensed += nozzle_count * pre_dispense
             if reagent.volume:
@@ -4212,7 +4212,7 @@ class Protocol(object):
                 raise ValueError("Each sample or control must indicate a "
                                  "volume of type unit. %s" % e)
             if (s.get("captured_events") and not
-            isinstance(s.get("captured_events"), int)):
+                    isinstance(s.get("captured_events"), int)):
                 raise TypeError("captured_events is optional, if given it"
                                 " must be of type integer.")
         for c in controls:
@@ -4221,7 +4221,7 @@ class Protocol(object):
                                 "indicating the colors/channels that this"
                                 " control is to be used for.")
             if (c.get("minimize_bleed") and not
-            isinstance(c.get("minimize_bleed"), list)):
+                    isinstance(c.get("minimize_bleed"), list)):
                 raise TypeError("Minimize_bleed must be of type list.")
             elif c.get("minimize_bleed"):
                 for b in c["minimize_bleed"]:
@@ -4275,7 +4275,7 @@ class Protocol(object):
                                         "type dict.")
                     else:
                         if (not c.get("name") or not
-                        isinstance(c.get("name"), str)):
+                                isinstance(c.get("name"), str)):
                             raise TypeError("Each color must have a `name` "
                                             "that is of type string.")
                         if c.get("emission_wavelength"):
@@ -5506,7 +5506,7 @@ class Protocol(object):
             raise TypeError("num_images must be a positive integer.")
         if magnification:
             if not isinstance(magnification, (float, int)) or \
-                    magnification <= 0:
+                magnification <= 0:
                 raise TypeError("magnification must be a number.")
         if backlighting:
             if not isinstance(backlighting, bool):
@@ -5598,10 +5598,10 @@ class Protocol(object):
         """
         last_instruction = self.instructions[-1] if self.instructions else None
         maybe_same_instruction = (
-                new_instruction is False and
-                last_instruction and
-                isinstance(last_instruction, MagneticTransfer) and
-                last_instruction.data.get("magnetic_head") == head
+            new_instruction is False and
+            last_instruction and
+            isinstance(last_instruction, MagneticTransfer) and
+            last_instruction.data.get("magnetic_head") == head
         )
         # Overwriting __dict__ since that's edited on __init__ and we use it
         # for downstream checks
@@ -6530,6 +6530,12 @@ class Protocol(object):
         if density:
             if not isinstance(density, list):
                 density = [density] * count
+            elif len(density) != count:
+                raise ValueError(
+                    "the length of provided density: {} does "
+                    "not match the number of transports."
+                    "".format(len(density))
+                )
             density = [parse_unit(d, "mg/ml") for d in density]
             for d in density:
                 if d.magnitude <= 0:
@@ -6538,6 +6544,7 @@ class Protocol(object):
                         "".format(d)
                     )
         else:
+            # if density is None, it should still be a list of None
             density = [density] * count
 
         if not isinstance(source_liquid, list):
@@ -6623,7 +6630,7 @@ class Protocol(object):
                     location_transports = location_helper(src, des, transfer_vol, met, dens)
                     source_transports = location_transports[0]["transports"]
                     instruction_mode = mode
-                    if instruction_mode is None:
+                    if not instruction_mode:
                         instruction_mode = LiquidHandle.builders.desired_mode(source_transports, mode)
                     instructions.append(
                         LiquidHandle(
@@ -6642,8 +6649,8 @@ class Protocol(object):
         # if one tip is true then there's a locations list
         if locations:
             source_transports = locations[0]["transports"]
-            if mode is None:
-                mode = LiquidHandle.builders.desired_mode(source_transports, mode)
+            # if not mode:
+            mode = LiquidHandle.builders.desired_mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
                     locations,
@@ -6762,7 +6769,6 @@ class Protocol(object):
         --------
         Mix : base LiquidHandleMethod for mix operations
         """
-
         def location_helper(aliquot, volume, method):
             """Generates LiquidHandle mix locations
 
@@ -6874,7 +6880,7 @@ class Protocol(object):
                 location_transports = location_helper(wel, vol, met)
                 source_transports = location_transports[0]["transports"]
                 instruction_mode = mode
-                if instruction_mode is None:
+                if not instruction_mode:
                     instruction_mode = LiquidHandle.builders.desired_mode(source_transports, mode)
                 instructions.append(
                     LiquidHandle(
@@ -6892,7 +6898,7 @@ class Protocol(object):
         # if one tip is true then there's a locations list
         if locations:
             source_transports = locations[0]["transports"]
-            if mode is None:
+            if not mode:
                 mode = LiquidHandle.builders.desired_mode(source_transports, mode)
             instructions.append(
                 LiquidHandle(
@@ -6948,7 +6954,6 @@ class Protocol(object):
         TypeError
             If specified destination is not of type Well
         """
-
         def euclidean_distance(point_a, point_b):
             """
             Calculate the euclidean distance between a pair of xy coordinates

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1385,7 +1385,7 @@ class Protocol(object):
                              " modes: {}.You specified: {}."
                              "".format(sequencer,
                                        ', '.join(valid_sequencers[
-                                                sequencer]["modes"]),
+                                                 sequencer]["modes"]),
                                        mode)
                              )
         if index not in valid_indices:
@@ -1533,7 +1533,7 @@ class Protocol(object):
 
         if not isinstance(wells, list):
             raise TypeError("Unknown input. SangerSeq wells accepts either a"
-                            "Well, a WellGroup, or a list of well indices")
+                             "Well, a WellGroup, or a list of well indices")
 
         return self._append_and_return(
             SangerSeq(cont, wells, dataref, type, primer))
@@ -5506,7 +5506,7 @@ class Protocol(object):
             raise TypeError("num_images must be a positive integer.")
         if magnification:
             if not isinstance(magnification, (float, int)) or \
-                magnification <= 0:
+               magnification <= 0:
                 raise TypeError("magnification must be a number.")
         if backlighting:
             if not isinstance(backlighting, bool):

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -34,12 +34,25 @@ class TestLiquidHandleBuilder(object):
     def test_transport_builder(self):
         transport = {
             "volume": Unit(1, "uL"),
+            "density": None,
             "pump_override_volume": Unit(2, "uL"),
             "flowrate": LiquidHandle.builders.flowrate(target="2:uL/s"),
             "delay_time": Unit(5, "s"),
             "mode_params": LiquidHandle.builders.mode_params(liquid_class="air")
         }
         assert LiquidHandle.builders.transport(**transport) == transport
+
+    def test_transports_with_denisty_buider(self):
+        transport = {
+            "volume": Unit(5, "uL"),
+            "density": Unit(1, "mg/ml"),
+            "pump_override_volume": Unit(2, "uL"),
+            "flowrate": LiquidHandle.builders.flowrate(target="2:uL/s"),
+            "delay_time": Unit(5, "s"),
+            "mode_params": LiquidHandle.builders.mode_params(liquid_class="air")
+        }
+        density = LiquidHandle.builders.transport(**transport)["density"]
+        assert density == Unit(1, "mg/ml")
 
     def test_flowrate_builder(self):
         flowrate = {

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -21,6 +21,19 @@ class TestInstuctionBuilders(object):
 
 
 class TestLiquidHandleBuilder(object):
+    asp_transport = LiquidHandle.builders.transport(
+        volume=Unit(1, "uL"),
+        density=None,
+        pump_override_volume=Unit(2, "uL"),
+        flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+        delay_time=Unit(0.5, "s"),
+        mode_params=LiquidHandle.builders.mode_params(
+            liquid_class="air",
+            position_z=LiquidHandle.builders.position_z(
+                reference="preceding_position")
+        )
+    )
+
     def test_location_builder(self):
         location = {
             "location": "test_well/0",
@@ -42,7 +55,7 @@ class TestLiquidHandleBuilder(object):
         }
         assert LiquidHandle.builders.transport(**transport) == transport
 
-    def test_transports_with_denisty_buider(self):
+    def test_transports_with_denisty_builder(self):
         transport = {
             "volume": Unit(5, "uL"),
             "density": Unit(1, "mg/ml"),
@@ -199,3 +212,70 @@ class TestLiquidHandleBuilder(object):
             "flowrate": LiquidHandle.builders.flowrate(target="1:uL/s")
         }
         assert LiquidHandle.builders.blowout(**blowout) == blowout
+
+    def test_mode_builder(self):
+        transports_air = [
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="air",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            ),
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class=None,
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            )
+        ]
+        transports_viscous = [
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="air",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            ),
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="viscous",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            )
+        ]
+        mode_air = {
+            "transports": transports_air,
+            "mode": None
+        }
+        mode_viscous = {
+            "transports": transports_viscous,
+            "mode": None
+        }
+        assert LiquidHandle.builders.mode(**mode_air) == "air_displacement"
+        assert LiquidHandle.builders.mode(**mode_viscous) == "positive_displacement"
+        # failure tests
+        with pytest.raises(ValueError):
+            LiquidHandle.builders.mode(transports_air, "foo")

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -5,7 +5,7 @@ from autoprotocol.instruction import LiquidHandle
 from autoprotocol import Unit
 
 
-class TestInstuctionBuilders(object):
+class TestInstructionBuilders(object):
     def test_shape_builder(self):
         shape = {"rows": 1, "columns": 12, "format": "SBS96"}
         assert LiquidHandle.builders.shape(**shape) == shape
@@ -163,7 +163,8 @@ class TestLiquidHandleBuilder(object):
         }
 
         assert(
-            LiquidHandle.builders.position_z(**extra_detection_arguments_positions_z) ==
+            LiquidHandle.builders.position_z(
+                **extra_detection_arguments_positions_z) ==
             extra_detection_arguments_positions_z
         )
 
@@ -219,7 +220,8 @@ class TestLiquidHandleBuilder(object):
                 volume=Unit(1, "uL"),
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="air",
@@ -231,7 +233,8 @@ class TestLiquidHandleBuilder(object):
                 volume=Unit(1, "uL"),
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="air",
@@ -245,7 +248,8 @@ class TestLiquidHandleBuilder(object):
                 volume=Unit(1, "uL"),
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="air",
@@ -257,7 +261,8 @@ class TestLiquidHandleBuilder(object):
                 volume=Unit(1, "uL"),
                 density=None,
                 pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
                     liquid_class="viscous",
@@ -275,7 +280,8 @@ class TestLiquidHandleBuilder(object):
             "mode": None
         }
         assert LiquidHandle.builders.mode(**mode_air) == "air_displacement"
-        assert LiquidHandle.builders.mode(**mode_viscous) == "positive_displacement"
+        assert LiquidHandle.builders.mode(**mode_viscous) == \
+            "positive_displacement"
         # failure tests
         with pytest.raises(ValueError):
             LiquidHandle.builders.mode(transports_air, "foo")

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -234,7 +234,7 @@ class TestLiquidHandleBuilder(object):
                 flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
                 mode_params=LiquidHandle.builders.mode_params(
-                    liquid_class=None,
+                    liquid_class="air",
                     position_z=LiquidHandle.builders.position_z(
                         reference="preceding_position")
                 )

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -214,7 +214,7 @@ class TestLiquidHandleBuilder(object):
         }
         assert LiquidHandle.builders.blowout(**blowout) == blowout
 
-    def test_mode_builder(self):
+    def test_desired_mode_builder(self):
         transports_air = [
             LiquidHandle.builders.transport(
                 volume=Unit(1, "uL"),
@@ -271,6 +271,62 @@ class TestLiquidHandleBuilder(object):
                 )
             )
         ]
+        transports_none = [
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class=None,
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            ),
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class=None,
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            )
+        ]
+        transports_invalid = [
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="viscous",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            ),
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="default",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position")
+                )
+            )
+        ]
         mode_air = {
             "transports": transports_air,
             "mode": None
@@ -279,9 +335,22 @@ class TestLiquidHandleBuilder(object):
             "transports": transports_viscous,
             "mode": None
         }
-        assert LiquidHandle.builders.mode(**mode_air) == "air_displacement"
-        assert LiquidHandle.builders.mode(**mode_viscous) == \
+        mode_none = {
+            "transports": transports_none,
+            "mode": None
+        }
+        mode_viscous_air = {
+            "transports": transports_viscous,
+            "mode": "air_displacement"
+        }
+        assert LiquidHandle.builders.desired_mode(**mode_air) == "air_displacement"
+        assert LiquidHandle.builders.desired_mode(**mode_viscous) == \
             "positive_displacement"
+        assert LiquidHandle.builders.desired_mode(**mode_none) == "air_displacement"
+        assert LiquidHandle.builders.desired_mode(**mode_viscous_air) == \
+             "air_displacement"
         # failure tests
         with pytest.raises(ValueError):
-            LiquidHandle.builders.mode(transports_air, "foo")
+            LiquidHandle.builders.desired_mode(transports_air, "foo")
+        with pytest.raises(ValueError):
+            LiquidHandle.builders.desired_mode(transports_invalid, None)

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -348,7 +348,7 @@ class TestLiquidHandleBuilder(object):
             "positive_displacement"
         assert LiquidHandle.builders.desired_mode(**mode_none) == "air_displacement"
         assert LiquidHandle.builders.desired_mode(**mode_viscous_air) == \
-             "air_displacement"
+            "air_displacement"
         # failure tests
         with pytest.raises(ValueError):
             LiquidHandle.builders.desired_mode(transports_air, "foo")

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -108,6 +108,14 @@ class TestLiquidClassTransfer(LiquidHandleTester):
             num_wells * transfers_per_well * transports_per_transfer
         )
 
+    def test_generates_liquid_handle_with_density(self):
+        self.p.transfer(
+            self.flat.well(0), self.flat.well(0), "1:uL",
+            density=Unit(1.1, "mg/ml")
+        )
+        inst = self.p.instructions[-1]
+        assert inst.op == "liquid_handle"
+        assert inst.data["locations"][0]["transports"][4]["density"] == Unit(1.1, "mg/ml")
 
 class TestLiquidClassTransferMultiChannel(LiquidHandleTester):
     def test_updates_well_volume(self):

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -117,6 +117,16 @@ class TestLiquidClassTransfer(LiquidHandleTester):
         assert inst.op == "liquid_handle"
         assert inst.data["locations"][0]["transports"][4]["density"] == Unit(1.1, "mg/ml")
 
+    def test_generates_liquid_handle_with_mode(self):
+        self.p.transfer(
+            self.flat.well(0), self.flat.well(0), "1:uL",
+            mode="positive_displacement"
+        )
+        inst = self.p.instructions[-1]
+        assert inst.op == "liquid_handle"
+        assert inst.data["mode"] == "positive_displacement"
+
+
 class TestLiquidClassTransferMultiChannel(LiquidHandleTester):
     def test_updates_well_volume(self):
         source_volume = Unit(30, "uL")

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -126,6 +126,15 @@ class TestLiquidClassTransfer(LiquidHandleTester):
         assert inst.op == "liquid_handle"
         assert inst.data["mode"] == "positive_displacement"
 
+    def test_generates_liquid_handle_without_mode(self):
+        self.p.transfer(
+            self.flat.well(0), self.flat.well(0), "1:uL",
+            mode=None
+        )
+        inst = self.p.instructions[-1]
+        assert inst.op == "liquid_handle"
+        assert inst.data["mode"] == "air_displacement"
+
 
 class TestLiquidClassTransferMultiChannel(LiquidHandleTester):
     def test_updates_well_volume(self):

--- a/test/liquid_handle_unit_test.py
+++ b/test/liquid_handle_unit_test.py
@@ -124,6 +124,7 @@ class LiquidHandleMethodTester(object):
     )
     asp_transport = LiquidHandle.builders.transport(
         volume=Unit(1, "uL"),
+        density=None,
         pump_override_volume=Unit(2, "uL"),
         flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
         delay_time=Unit(0.5, "s"),
@@ -262,6 +263,24 @@ class TestLiquidHandleMethod(LiquidHandleMethodTester):
         assert self.lhm._transports[1] == prime_aspirate
         assert self.lhm._transports[3] == prime_dispense
 
+    def test_aspirate_simple_with_density(self):
+        tip_position = self.asp_transport["mode_params"]["tip_position"]
+        self.lhm._aspirate_simple(
+            # pylint: disable=invalid-unary-operand-type
+            volume=-self.asp_transport["volume"],
+            # pylint: disable=invalid-unary-operand-type
+            calibrated_vol=-self.asp_transport["pump_override_volume"],
+            initial_z=self.well_top_z,
+            position_x=tip_position["position_x"],
+            position_y=tip_position["position_y"],
+            flowrate=self.asp_transport["flowrate"],
+            delay_time=self.asp_transport["delay_time"],
+            liquid_class=self.asp_transport["mode_params"]["liquid_class"],
+            density=Unit(1, "mg/ml")
+        )
+        assert self.lhm._transports[0] == self.well_top_transport
+        assert self.lhm._transports[1]["density"] == Unit(1, "mg/ml")
+
     def test_dispense_simple(self):
         tip_position = self.asp_transport["mode_params"]["tip_position"]
         self.lhm._dispense_simple(
@@ -276,6 +295,22 @@ class TestLiquidHandleMethod(LiquidHandleMethodTester):
         )
         assert self.lhm._transports[0] == self.well_top_transport
         assert self.lhm._transports[1] == self.asp_transport
+
+    def test_dispense_simple_with_density(self):
+        tip_position = self.asp_transport["mode_params"]["tip_position"]
+        self.lhm._dispense_simple(
+            volume=self.asp_transport["volume"],
+            calibrated_vol=self.asp_transport["pump_override_volume"],
+            initial_z=self.well_top_z,
+            position_x=tip_position["position_x"],
+            position_y=tip_position["position_y"],
+            flowrate=self.asp_transport["flowrate"],
+            delay_time=self.asp_transport["delay_time"],
+            liquid_class=self.asp_transport["mode_params"]["liquid_class"],
+            density=Unit(1, "mg/ml")
+        )
+        assert self.lhm._transports[0] == self.well_top_transport
+        assert self.lhm._transports[1]["density"] == Unit(1, "mg/ml")
 
     def test_mix(self):
         mix_reps = 4

--- a/test/liquid_handle_unit_test.py
+++ b/test/liquid_handle_unit_test.py
@@ -124,7 +124,6 @@ class LiquidHandleMethodTester(object):
     )
     asp_transport = LiquidHandle.builders.transport(
         volume=Unit(1, "uL"),
-        density=None,
         pump_override_volume=Unit(2, "uL"),
         flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
         delay_time=Unit(0.5, "s"),


### PR DESCRIPTION
The viscosity of liquid samples used in a laboratory ranges from very fluid (ie. acetone) to very thick (ie. glycerol). A limitation to the current `liquid_handle` instruction is that there is only an `air-displacement` mode to handle water-like liquid. While this is sufficient for liquids with relatively low viscosity, they should not be used for viscous samples due to the inability for air pressure to overcome the surface tension. 

To provide a more accurate way to handle these samples, the `positive-displacement` mode should be used for 'viscous' liquid class. Furthermore, there are devices that are capable of requesting liquid transfer amount in mass instead of volume. To allow such feature, optional density parameter is added to be able to convert mass to volume (and vice versa) as needed.

Finally, these changes only add optional parameter, and does not affect the current default behavior of the LiuqidHandle instruction. 'air_displacement' mode is used for all liquids that are liquid_class not indicated (None), 'default' or 'air' as previously done.