### PR TITLE
changing how Protocol.propagate_properties copies properties to destination wells

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1827,42 +1827,45 @@ class LiquidHandleBuilders(InstructionBuilders):
         ValueError
             multiple liquid_class exists in one LiquidHandle
 
-        Example Usage:
-        .. code-block:: python
-        example_transports = [
-            LiquidHandle.builders.transport(
-                volume=Unit(1, "uL"),
-                density=None,
-                pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")
-                ),
-                delay_time=Unit(0.5, "s"),
-                mode_params=LiquidHandle.builders.mode_params(
-                    liquid_class="air",
-                    position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position"
-                    )
-                )
-            ),
-            LiquidHandle.builders.transport(
-                volume=Unit(1, "uL"),
-                density=None,
-                pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")
-                ),
-                delay_time=Unit(0.5, "s"),
-                mode_params=LiquidHandle.builders.mode_params(
-                    liquid_class="viscous",
-                    position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position"
-                    )
-                )
-            )
-        ]
+        Examples
+        --------
 
-        LiquidHandle.builders.desired_mode(example_transports, None)
+        .. code-block:: python
+
+            example_transports = [
+                LiquidHandle.builders.transport(
+                    volume=Unit(1, "uL"),
+                    density=None,
+                    pump_override_volume=Unit(2, "uL"),
+                    flowrate=LiquidHandle.builders.flowrate(
+                        target=Unit(10, "uL/s")
+                    ),
+                    delay_time=Unit(0.5, "s"),
+                    mode_params=LiquidHandle.builders.mode_params(
+                        liquid_class="air",
+                        position_z=LiquidHandle.builders.position_z(
+                            reference="preceding_position"
+                        )
+                    )
+                ),
+                LiquidHandle.builders.transport(
+                    volume=Unit(1, "uL"),
+                    density=None,
+                    pump_override_volume=Unit(2, "uL"),
+                    flowrate=LiquidHandle.builders.flowrate(
+                        target=Unit(10, "uL/s")
+                    ),
+                    delay_time=Unit(0.5, "s"),
+                    mode_params=LiquidHandle.builders.mode_params(
+                        liquid_class="viscous",
+                        position_z=LiquidHandle.builders.position_z(
+                            reference="preceding_position"
+                        )
+                    )
+                )
+            ]
+
+            LiquidHandle.builders.desired_mode(example_transports, None)
 
         This will return "positive_displacement" based on the "viscous" liquid
         class. Note that "air" (which defaults to "air_displacement") does not

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1830,10 +1830,44 @@ class LiquidHandleBuilders(InstructionBuilders):
         Example Usage:
         .. code-block:: python
         example_transports = [
-            LiquidHandle.builders.transport(),
-            LiquidHandle.builders.transport()
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")
+                ),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="air",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position"
+                    )
+                )
+            ),
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(
+                    target=Unit(10, "uL/s")
+                ),
+                delay_time=Unit(0.5, "s"),
+                mode_params=LiquidHandle.builders.mode_params(
+                    liquid_class="viscous",
+                    position_z=LiquidHandle.builders.position_z(
+                        reference="preceding_position"
+                    )
+                )
+            )
         ]
 
+        LiquidHandle.builders.desired_mode(example_transports, None)
+
+        This will return "positive_displacement" based on the "viscous" liquid
+        class. Note that "air" (which defaults to "air_displacement") does not
+        cause a conflict since "air" is often applied in additional transfers
+        of air (such as blowout) for any liquid class, and is disregarded.
         LiquidHandle.builders.desired_mode(example_transports, None)
 
         This will return "positive_displacement" based on the "viscous" liquid

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1755,40 +1755,43 @@ class LiquidHandleBuilders(InstructionBuilders):
         or push the liquid sufficiently through transfer tip, it will
         default to "positive_displacement" unless otherwise specified.
 
-        Example Usage:
+        Examples
+        --------
+
         .. code-block:: python
-        example_transports = [
-            LiquidHandle.builders.transport(
-                volume=Unit(1, "uL"),
-                density=None,
-                pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")
+
+            example_transports = [
+                LiquidHandle.builders.transport(
+                    volume=Unit(1, "uL"),
+                    density=None,
+                    pump_override_volume=Unit(2, "uL"),
+                    flowrate=LiquidHandle.builders.flowrate(
+                        target=Unit(10, "uL/s")
+                    ),
+                    delay_time=Unit(0.5, "s"),
+                    mode_params=LiquidHandle.builders.mode_params(
+                        liquid_class="air",
+                        position_z=LiquidHandle.builders.position_z(
+                            reference="preceding_position"
+                        )
+                    )
                 ),
-                delay_time=Unit(0.5, "s"),
-                mode_params=LiquidHandle.builders.mode_params(
-                    liquid_class="air",
-                    position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position"
+                LiquidHandle.builders.transport(
+                    volume=Unit(1, "uL"),
+                    density=None,
+                    pump_override_volume=Unit(2, "uL"),
+                    flowrate=LiquidHandle.builders.flowrate(
+                        target=Unit(10, "uL/s")
+                    ),
+                    delay_time=Unit(0.5, "s"),
+                    mode_params=LiquidHandle.builders.mode_params(
+                        liquid_class="viscous",
+                        position_z=LiquidHandle.builders.position_z(
+                            reference="preceding_position"
+                        )
                     )
                 )
-            ),
-            LiquidHandle.builders.transport(
-                volume=Unit(1, "uL"),
-                density=None,
-                pump_override_volume=Unit(2, "uL"),
-                flowrate=LiquidHandle.builders.flowrate(
-                    target=Unit(10, "uL/s")
-                ),
-                delay_time=Unit(0.5, "s"),
-                mode_params=LiquidHandle.builders.mode_params(
-                    liquid_class="viscous",
-                    position_z=LiquidHandle.builders.position_z(
-                        reference="preceding_position"
-                    )
-                )
-            )
-        ]
+            ]
 
         LiquidHandle.builders.desired_mode(example_transports, None)
 
@@ -1872,8 +1875,8 @@ class LiquidHandleBuilders(InstructionBuilders):
         if not modes:
             raise ValueError(
                 "modes: {} resulted in an empty set. Make sure valid mode is "
-                "added for each liquid class."
-            ).format(modes)
+                "added for each liquid class.".format(modes)
+            )
         # return error if there are incompatible liquid_class a set of
         # transports.
         if len(set(modes)) > 1:

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1826,6 +1826,20 @@ class LiquidHandleBuilders(InstructionBuilders):
             liquid_class did not resolve to a mode
         ValueError
             multiple liquid_class exists in one LiquidHandle
+
+        Example Usage:
+        .. code-block:: python
+        example_transports = [
+            LiquidHandle.builders.transport(),
+            LiquidHandle.builders.transport()
+        ]
+
+        LiquidHandle.builders.desired_mode(example_transports, None)
+
+        This will return "positive_displacement" based on the "viscous" liquid
+        class. Note that "air" (which defaults to "air_displacement") does not
+        cause a conflict since "air" is often applied in additional transfers
+        of air (such as blowout) for any liquid class, and is disregarded.
         """
         # dict for default dispense mode for each liquid_class
         liquid_class_to_dispense_mode = {

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -7101,7 +7101,7 @@ class Protocol(object):
             )
         for source_well, dest_well in zip(source_wells, dest_wells):
             if self.propagate_properties:
-                dest_well.add_properties(source_well.properties)
+                dest_well.set_properties(source_well.properties)
 
             if source_well.volume is not None:
                 source_well.volume -= volume

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+
+* :bug:`230` Changing Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 * :support:`228` Remove Phabricator references
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,14 @@
 =========
 Changelog
 =========
+<<<<<<< HEAD
 
 
 * :bug:`230` Changing Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
+=======
+* :bug:`230` Changing Protocol.propagate_properties to use Well.set_properties
+>>>>>>> adding PR bug number
 * :support:`228` Remove Phabricator references
 
 * :release:`6.1.2 <2020-02-18>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,11 +2,15 @@
 Changelog
 =========
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 
 * :bug:`230` Changing Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 =======
+=======
+
+>>>>>>> fixing bug in autoprotocol.builders preventing travis build
 * :bug:`230` Changing Protocol.propagate_properties to use Well.set_properties
 >>>>>>> adding PR bug number
 * :support:`228` Remove Phabricator references

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 * :support:`228` Remove Phabricator references
 
 * :release:`6.1.2 <2020-02-18>`


### PR DESCRIPTION
https://strateos.atlassian.net/jira/software/projects/STDEV/boards/58?selectedIssue=STDEV-35 

User warnings are preventing protocol package from building and uploading to web. This is due to setting Protocol.propagate_properties to True, because it will use the .add_properties method instead of the .set_properties method. The .add_properties method purposefully uses user warnings when aliquot properties are overwritten. By changing to .set_properties, we can avoid building failures and copy the aliquot properties to the destination aliquot.