### PR TITLE
Fixing propagate properties method

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -7101,7 +7101,7 @@ class Protocol(object):
             )
         for source_well, dest_well in zip(source_wells, dest_wells):
             if self.propagate_properties:
-                dest_well.add_properties(source_well.properties)
+                dest_well.set_properties(source_well.properties)
 
             if source_well.volume is not None:
                 source_well.volume -= volume

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`232` Changing Protocol.propagate_properties to use Well.set_properties
+* :bug:`233` Changing Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 * :support:`228` Remove Phabricator references
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`232` Changing Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 * :support:`228` Remove Phabricator references
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`233` Changing Protocol.propagate_properties to use Well.set_properties
+* :bug:`233` Change Protocol.propagate_properties to use Well.set_properties
 * :bug:`231` Fix LiquidHandleBuilders method desired_mode docstring preventing Travis build
 * :support:`228` Remove Phabricator references
 


### PR DESCRIPTION
https://strateos.atlassian.net/jira/software/projects/STDEV/boards/58?selectedIssue=STDEV-35

User warnings are preventing protocol package from building and uploading to web. This is due to setting Protocol.propagate_properties to True, because it will use the .add_properties method instead of the .set_properties method. The .add_properties method purposefully uses user warnings when aliquot properties are overwritten. By changing to .set_properties, we can avoid building failures and copy the aliquot properties to the destination aliquot.