### PR TITLE
Propagate aliquot properties bug

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -7053,7 +7053,7 @@ class Protocol(object):
             )
         for source_well, dest_well in zip(source_wells, dest_wells):
             if self.propagate_properties:
-                dest_well.set_properties(source_well.properties)
+                dest_well.add_properties(source_well.properties)
 
             if source_well.volume is not None:
                 source_well.volume -= volume

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`242` Revert Protocol.propagate_properties to use Well.add_properties
+* :bug:`244` Revert Protocol.propagate_properties to use Well.add_properties
 * :support:`241` Deprecate support for Python 3.5, add support for Python 3.8
 * :feature:`238` Add 96-well-v-bottom container type
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`242` Revert Protocol.propagate_properties to use Well.add_properties
 * :support:`241` Deprecate support for Python 3.5, add support for Python 3.8
 * :feature:`238` Add 96-well-v-bottom container type
 


### PR DESCRIPTION
Modifications to the the method that Protocol.propagate_properties uses to propagate properties, solved internal Strateos issues when overwriting an aliquot property key. The main issue is the warning caused by overwriting keys is sent to stdout which prevents the building and and execution of the protocol on the Strateos Web app. However, the change breaks Ginkgo's expectation of how the properties are propagated. This PR reverts the method used back to the original `.add_properties` method. Since the original bug only is seen internally in a very specific edge case.