### PR TITLE
feat: Bump Pint to 0.9

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`248` Bump Pint version to 0.9
 * :support:`247` Add `black` as auto-formatter to pre-commit workflow
 * :bug:`244` Revert Protocol.propagate_properties to use Well.add_properties
 * :feature:`239` Add `absorbance` and `fluorescence` capabilities to 96-well-v-bottom container type

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     license="BSD",
     maintainer_email="support@strateos.com",
     version=__version__,  # pylint: disable=undefined-variable
-    install_requires=["Pint==0.8.1"],
+    install_requires=["Pint==0.9"],
     python_requires=">=3.6",
     tests_require=test_deps,
     extras_require={"docs": doc_deps, "test": test_deps},


### PR DESCRIPTION
As we're preparing for a major release, this is an opportunity to
upgrade some of our base dependencies.

This upgrades the base Pint version to 0.9 which brings some bugfixes
and better interop with other Python libraries.

See https://github.com/hgrecco/pint/blob/master/CHANGES#L259

Ideally we'll bump to 0.11, but there are some incompat issues which
we'll need to investigate.