### PR TITLE
 docs: Bump documentation dependencies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`249` Update documentation dependencies, notably Sphinx to >=2.4
 * :support:`247` Add `black` as auto-formatter to pre-commit workflow
 * :bug:`244` Revert Protocol.propagate_properties to use Well.add_properties
 * :feature:`239` Add `absorbance` and `fluorescence` capabilities to 96-well-v-bottom container type

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath("../autoprotocol"))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.7"
+needs_sphinx = "2.4"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -291,6 +291,8 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
+
+    extensions.append("sphinx_rtd_theme")
 
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ test_deps = [
 ]
 
 doc_deps = [
-    "releases>=1.5, <2",
-    "Sphinx>=1.7, <1.8",
-    "sphinx_rtd_theme>=0.4, <1",
+    "releases>=1.6.3, <2",
+    "Sphinx>=2.4, <3",
+    "sphinx_rtd_theme>=0.4.3, <1",
     "semantic-version==2.6.0",
 ]
 


### PR DESCRIPTION
As we're preparing for a major release, this is an opportunity to
upgrade some of our base dependencies.

This PR bumps our base Sphinx version to >=2.4, and also bumps our
other documentation related dependencies to their newest versions.

Notably, this brings in many bugfixes and some nicer UI elements such as
a nicer search bar.

The full changelog is available here:
https://www.sphinx-doc.org/en/master/changes.html#release-2-4-4-released-mar-05-2020

Verified that the docs build fine.