### PR TITLE
 build: Bump test dependencies

### DIFF
--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -822,14 +822,14 @@ class Fluorescence(Instruction):
                 "calculated_from_wells": []
             }
 
-    manual: str, Unit, optional
-        parameter available within "position_z" to set the distance from
-        the optics to the plate transport.
-    calculated_from_wells: list, WellGroup, Well, optional
-        parameter available within "position_z" to set the distance from
-        the optics to the plate transport.  If specified, the average
-        optimal (maximal signal) distance will be chosen from the list
-        of wells and applied to all measurements.
+        manual: str, Unit, optional
+            parameter available within "position_z" to set the distance from
+            the optics to the plate transport.
+        calculated_from_wells: list, WellGroup, Well, optional
+            parameter available within "position_z" to set the distance from
+            the optics to the plate transport.  If specified, the average
+            optimal (maximal signal) distance will be chosen from the list
+            of wells and applied to all measurements.
     settle_time: Unit, optional
         the time before the start of the measurement, defaults
         to vendor specifications

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1769,7 +1769,8 @@ class Protocol(object):
             if is_resource_id:
                 reagent, resource_id, reagent_source = None, reagent, None
             else:
-                reagent, resource_id, reagent_source = reagent, None, None
+                # reagent remains unchanged
+                resource_id, reagent_source = None, None
 
         self._remove_cover(ref, "dispense to")
 

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -135,9 +135,7 @@ class UnitStringError(UnitError):
 
 
 class UnitValueError(UnitError):
-    message_text = (
-        "Invalid value '%s'; when building a Unit " "the value must be numeric."
-    )
+    message_text = "Invalid value '%s'; when building a Unit the value must be numeric."
 
 
 class UnitUnitsError(UnitError):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`250` Bump test dependencies, notably pytest to >=5.4, pylint to 2.5.2 and tox >=3.15
 * :feature:`248` Bump Pint version to 0.9
 * :support:`247` Add `black` as auto-formatter to pre-commit workflow
 * :support:`245` Add expected propagate_properties behavior tests

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,10 @@ class PyTest(TestCommand):
 test_deps = [
     "coverage>=4.5, <5",
     "pre-commit>=2.4, <3",
-    "pylint>=1.9, <2",
-    "pytest>=4, <5",
+    "pylint==2.5.2",  # should be consistent with .pre-commit-config.yaml
+    "pytest>=5.4, <6",
     "pytest-cov>=2, !=2.8.1",
-    "tox>=3.7, <4",
+    "tox>=3.15, <4",
 ]
 
 doc_deps = [
@@ -68,6 +68,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7" "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
As we're preparing for a major release, this is an opportunity to
upgrade some of our base dependencies.

This bumps our pytest dependency by one major version. Notably py35
support was dropped, and there has been multiple deprecations which we
are not affected by. There's also a bunch of bugfixes/improvements.

Pylint has been pinned to 2.5.2, which is the same as what we're running
in pre-commit.

Tox has been bumped to 3.15, which brings notable speedups.