### PR TITLE
 build: add code coverage badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,18 @@ jobs:
   - python: '3.6'
     env: TOXENV=lint
   - python: '3.6'
-    env: TOXENV=clean,py36,stats
+    env: TOXENV=clean,py36,stats_xml
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'
     env: TOXENV=py38
 install:
 - pip install tox
+- pip install codecov
 script:
 - tox -v
+after_success:
+- codecov
 after_failure:
 - more .tox/log/* | cat
 - more .tox/*/log/* | cat

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,14 @@
    :target: https://travis-ci.org/autoprotocol/autoprotocol-python
    :alt: Build Status
 
+.. image:: https://codecov.io/gh/autoprotocol/autoprotocol-python/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/autoprotocol/autoprotocol-python
+   :alt: Code Coverage
+
 .. image:: https://badges.gitter.im/autoprotocol/autoprotocol-python.svg
    :target: https://gitter.im/autoprotocol/autoprotocol-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
    :alt: Gitter Chat
+
 
 Autoprotocol_ is the standard way to express experiments in life science. This repository contains a python library for generating Autoprotocol.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`251` Add code coverage badge
 * :support:`249` Update documentation dependencies, notably Sphinx to >=2.4
 * :feature:`248` Bump Pint version to 0.9
 * :support:`247` Add `black` as auto-formatter to pre-commit workflow

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ commands = coverage erase
 [testenv:stats]
 commands = coverage report -m --rcfile={toxinidir}/.coveragerc
 
+[testenv:stats_xml]
+# Used in CI for generating xml for codecov
+commands = coverage xml --rcfile={toxinidir}/.coveragerc
+
 [testenv:lint]
 deps = .[test, docs]
 commands = pre-commit run --all-files


### PR DESCRIPTION
 Add code coverage badge using codecov. Leverages existing coverage
 integration by adding an explicit `stats_xml` step for creating xml
 required by codecov.