### PR TITLE
docs: Use readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Python env setup to use docs
+python:
+   version: 3.6
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+            - docs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`252` Switch to using .readthedocs.yml for docs build config
 * :support:`251` Add code coverage badge
 * :support:`250` Bump test dependencies, notably pytest to >=5.4, pylint to 2.5.2 and tox >=3.15
 * :support:`249` Update documentation dependencies, notably Sphinx to >=2.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-Sphinx>=1.7,<2
-sphinx-rtd-theme
-releases
--e git://github.com/autoprotocol/autoprotocol-python.git@master#egg=autoprotocol


### PR DESCRIPTION
We had a separate doc/requirements.txt file that was previously used for
maintaing documentation dependencies for readthedocs.org

Switching to the readthedocs config file would allow us to remove that
duplicated file and use the right build environment for generating docs.