### PR TITLE
fix: compatibility with txappy

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1812,9 +1812,13 @@ class LiquidHandleBuilders(InstructionBuilders):
             return mode
 
         # get liquid_classes from transport input
-        liquid_classes = set(
-            [transport["mode_params"]["liquid_class"] for transport in transports]
-        )
+        mode_params = [transport["mode_params"] for transport in transports]
+        if all(mode_param is None for mode_param in mode_params):
+            liquid_classes = {None}
+        else:
+            liquid_classes = set(
+                [mode_param["liquid_class"] for mode_param in mode_params]
+            )
         # remove automatically added 'air' (e.g. from blowout steps) and None
         # classes.
         other_classes = liquid_classes - {"air", None}

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -291,6 +291,16 @@ class TestLiquidHandleBuilder(object):
                 ),
             ),
         ]
+        transports_no_mode_params = [
+            LiquidHandle.builders.transport(
+                volume=Unit(1, "uL"),
+                density=None,
+                pump_override_volume=Unit(2, "uL"),
+                flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
+                delay_time=Unit(0.5, "s"),
+                mode_params=None
+            )
+        ]
         transports_invalid = [
             LiquidHandle.builders.transport(
                 volume=Unit(1, "uL"),
@@ -326,6 +336,9 @@ class TestLiquidHandleBuilder(object):
             "transports": transports_viscous,
             "mode": "air_displacement",
         }
+        mode_no_mode_params = {
+            "transports": transports_no_mode_params, "mode": None
+        }
         assert LiquidHandle.builders.desired_mode(**mode_air) == "air_displacement"
         assert (
             LiquidHandle.builders.desired_mode(**mode_viscous)
@@ -335,6 +348,7 @@ class TestLiquidHandleBuilder(object):
         assert (
             LiquidHandle.builders.desired_mode(**mode_viscous_air) == "air_displacement"
         )
+        assert LiquidHandle.builders.desired_mode(**mode_no_mode_params) == "air_displacement"
         # failure tests
         with pytest.raises(ValueError):
             LiquidHandle.builders.desired_mode(transports_air, "foo")

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -298,7 +298,7 @@ class TestLiquidHandleBuilder(object):
                 pump_override_volume=Unit(2, "uL"),
                 flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
-                mode_params=None
+                mode_params=None,
             )
         ]
         transports_invalid = [
@@ -334,7 +334,7 @@ class TestLiquidHandleBuilder(object):
         mode_none = {"transports": transports_none, "mode": None}
         mode_viscous_air = {
             "transports": transports_viscous,
-            "mode": "air_displacement"
+            "mode": "air_displacement",
         }
         mode_no_mode_params = {"transports": transports_no_mode_params, "mode": None}
         assert LiquidHandle.builders.desired_mode(**mode_air) == "air_displacement"

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -298,7 +298,7 @@ class TestLiquidHandleBuilder(object):
                 pump_override_volume=Unit(2, "uL"),
                 flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
-                mode_params=None,
+                mode_params=None
             )
         ]
         transports_invalid = [
@@ -334,7 +334,7 @@ class TestLiquidHandleBuilder(object):
         mode_none = {"transports": transports_none, "mode": None}
         mode_viscous_air = {
             "transports": transports_viscous,
-            "mode": "air_displacement",
+            "mode": "air_displacement"
         }
         mode_no_mode_params = {"transports": transports_no_mode_params, "mode": None}
         assert LiquidHandle.builders.desired_mode(**mode_air) == "air_displacement"

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -298,7 +298,7 @@ class TestLiquidHandleBuilder(object):
                 pump_override_volume=Unit(2, "uL"),
                 flowrate=LiquidHandle.builders.flowrate(target=Unit(10, "uL/s")),
                 delay_time=Unit(0.5, "s"),
-                mode_params=None
+                mode_params=None,
             )
         ]
         transports_invalid = [
@@ -336,9 +336,7 @@ class TestLiquidHandleBuilder(object):
             "transports": transports_viscous,
             "mode": "air_displacement",
         }
-        mode_no_mode_params = {
-            "transports": transports_no_mode_params, "mode": None
-        }
+        mode_no_mode_params = {"transports": transports_no_mode_params, "mode": None}
         assert LiquidHandle.builders.desired_mode(**mode_air) == "air_displacement"
         assert (
             LiquidHandle.builders.desired_mode(**mode_viscous)
@@ -348,9 +346,10 @@ class TestLiquidHandleBuilder(object):
         assert (
             LiquidHandle.builders.desired_mode(**mode_viscous_air) == "air_displacement"
         )
-        assert LiquidHandle.builders.desired_mode(
-            **mode_no_mode_params
-        ) == "air_displacement"
+        assert (
+            LiquidHandle.builders.desired_mode(**mode_no_mode_params)
+            == "air_displacement"
+        )
         # failure tests
         with pytest.raises(ValueError):
             LiquidHandle.builders.desired_mode(transports_air, "foo")

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -348,7 +348,9 @@ class TestLiquidHandleBuilder(object):
         assert (
             LiquidHandle.builders.desired_mode(**mode_viscous_air) == "air_displacement"
         )
-        assert LiquidHandle.builders.desired_mode(**mode_no_mode_params) == "air_displacement"
+        assert LiquidHandle.builders.desired_mode(
+            **mode_no_mode_params
+        ) == "air_displacement"
         # failure tests
         with pytest.raises(ValueError):
             LiquidHandle.builders.desired_mode(transports_air, "foo")


### PR DESCRIPTION
fix: desired_mode
minimal_transfer in txappy returns None for `mode_params`. Updating ApPy to make it compatible.