### PR TITLE
feat: assign time_constraints to instance attribute

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -889,8 +889,14 @@ class Protocol(object):
             for a in dir(self)
             if not a.startswith("__") and not callable(getattr(self, a))
         ]
-
-        explicit_props = ["outs", "refs", "instructions", "time_constraints"]
+        # if either refs or instructions is empty raise error
+        if not self.refs or not self.instructions:
+            raise RuntimeError("there must be at least one instruction and a ref")
+        # time_constraints is an optional attribute and should not be serialized if value is []
+        if not self.time_constraints:
+            explicit_props = ["outs", "refs", "instructions"]
+        else:
+            explicit_props = ["outs", "refs", "instructions", "time_constraints"]
 
         return {
             attr: self._refify(getattr(self, attr))

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -896,11 +896,14 @@ class Protocol(object):
         # if either refs or instructions is empty raise error
         if not self.refs or not self.instructions:
             raise RuntimeError("there must be at least one instruction and a ref")
-        # time_constraints is an optional attribute and should not be serialized if value is []
-        if not self.time_constraints:
-            explicit_props = ["outs", "refs", "instructions"]
-        else:
-            explicit_props = ["outs", "refs", "instructions", "time_constraints"]
+
+        explicit_props = ["outs", "refs", "instructions"]
+        # attributes that are always serialized.
+        optional_props = ["time_constraints"]
+        # optional attributes that are serialized only when there are values
+        for prop in optional_props:
+            if getattr(self, prop):
+                explicit_props.append(prop)
 
         return {
             attr: self._refify(getattr(self, attr))

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -499,13 +499,6 @@ class Protocol(object):
 
         state_strings = ["start", "end"]
 
-        def add_time_constraint_internal(time_const):
-            setattr(
-                self,
-                "time_constraints",
-                (getattr(self, "time_constraints", []) + [time_const]),
-            )
-
         keys = []
 
         # Move the 4th param to mirror if the caller used the syntax
@@ -604,26 +597,19 @@ class Protocol(object):
         to_time_point = {keys[1]: to_dict["mark"]}
 
         if less_than is not None:
-            add_time_constraint_internal(
-                {"from": from_time_point, "to": to_time_point, "less_than": less_than,}
-            )
-
+            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "less_than": less_than}]
             if mirror:
                 self.add_time_constraint(to_dict, from_dict, less_than, mirror=False)
 
         if more_than is not None:
-            add_time_constraint_internal(
-                {"from": from_time_point, "to": to_time_point, "more_than": more_than}
-            )
+            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "more_than": more_than}]
 
         if ideal is not None:
             ideal_dict = dict(value=ideal)
             if optimization_cost is not None:
                 ideal_dict["optimization_cost"] = optimization_cost
 
-            add_time_constraint_internal(
-                {"from": from_time_point, "to": to_time_point, "ideal": ideal_dict}
-            )
+            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "ideal": ideal_dict}]
 
     def get_instruction_index(self):
         """Get index of the last appended instruction

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -126,7 +126,13 @@ class Protocol(object):
             }
     """
 
-    def __init__(self, refs=None, instructions=None, propagate_properties=False, time_constraints=None):
+    def __init__(
+        self,
+        refs=None,
+        instructions=None,
+        propagate_properties=False,
+        time_constraints=None,
+    ):
         super(Protocol, self).__init__()
         self.refs = refs or {}
         self.instructions = instructions or []
@@ -597,19 +603,25 @@ class Protocol(object):
         to_time_point = {keys[1]: to_dict["mark"]}
 
         if less_than is not None:
-            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "less_than": less_than}]
+            self.time_constraints += [
+                {"from": from_time_point, "to": to_time_point, "less_than": less_than}
+            ]
             if mirror:
                 self.add_time_constraint(to_dict, from_dict, less_than, mirror=False)
 
         if more_than is not None:
-            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "more_than": more_than}]
+            self.time_constraints += [
+                {"from": from_time_point, "to": to_time_point, "more_than": more_than}
+            ]
 
         if ideal is not None:
             ideal_dict = dict(value=ideal)
             if optimization_cost is not None:
                 ideal_dict["optimization_cost"] = optimization_cost
 
-            self.time_constraints += [{"from": from_time_point, "to": to_time_point, "ideal": ideal_dict}]
+            self.time_constraints += [
+                {"from": from_time_point, "to": to_time_point, "ideal": ideal_dict}
+            ]
 
     def get_instruction_index(self):
         """Get index of the last appended instruction

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -49,6 +49,8 @@ class Protocol(object):
     propagate_properties : bool, optional
         Whether liquid handling operations should propagate aliquot properties
         from source to destination wells.
+    time_constraints : List(time_constraints)
+        Pre-existing time_constraints that the protocol should be populated with.
 
     Examples
     --------

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -126,11 +126,12 @@ class Protocol(object):
             }
     """
 
-    def __init__(self, refs=None, instructions=None, propagate_properties=False):
+    def __init__(self, refs=None, instructions=None, propagate_properties=False, time_constraints=None):
         super(Protocol, self).__init__()
         self.refs = refs or {}
         self.instructions = instructions or []
         self.propagate_properties = propagate_properties
+        self.time_constraints = time_constraints or []
 
     def __repr__(self):
         return f"Protocol({self.__dict__})"

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -857,6 +857,10 @@ class Protocol(object):
             "time_constraints" and "outs", each of which contain the
             "refified" contents of their corresponding Protocol attribute.
 
+        Raises
+        ------
+        RuntimeError
+            If either refs or instructions attribute is empty
         """
         outs = {}
         # pragma pylint: disable=protected-access

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`258` Add time_constraints value to the Protocol attributes
 * :feature:`254` Add support for provisioning of resources by mass
 
 * :release:`7.0.1 <2020-06-02>`

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -448,6 +448,8 @@ class TestTimeConstraints(object):
         p.cover(plate_2)
         time_point_2 = p.get_instruction_index()
 
+        assert not p.as_dict()["time_constraints"]
+
         p.add_time_constraint(
             {"mark": time_point_1, "state": "start"},
             {"mark": time_point_1, "state": "end"},

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -448,8 +448,8 @@ class TestTimeConstraints(object):
         p.cover(plate_2)
         time_point_2 = p.get_instruction_index()
 
-        with pytest.raises(AttributeError):
-            p.time_constraints  # pylint: disable=pointless-statement
+        # with pytest.raises(AttributeError):
+        #     p.time_constraints  # pylint: disable=pointless-statement
 
         p.add_time_constraint(
             {"mark": time_point_1, "state": "start"},

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -448,9 +448,6 @@ class TestTimeConstraints(object):
         p.cover(plate_2)
         time_point_2 = p.get_instruction_index()
 
-        # with pytest.raises(AttributeError):
-        #     p.time_constraints  # pylint: disable=pointless-statement
-
         p.add_time_constraint(
             {"mark": time_point_1, "state": "start"},
             {"mark": time_point_1, "state": "end"},


### PR DESCRIPTION
`time_constraints pretty` was using a has then set pattern. Instead, we'll assign `time_constraint` value (list) to the attribute to be inherited by Protocol instances.