### PR TITLE
revert: Protocol.as_dict() empty instructions/refs

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -893,9 +893,6 @@ class Protocol(object):
             for a in dir(self)
             if not a.startswith("__") and not callable(getattr(self, a))
         ]
-        # if either refs or instructions is empty raise error
-        if not self.refs or not self.instructions:
-            raise RuntimeError("there must be at least one instruction and a ref")
 
         explicit_props = ["outs", "refs", "instructions"]
         # attributes that are always serialized.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`261` Revert empty Protocol assertion check in `as_dict()`
+
 * :release:`7.1.0 <2020-06-29>`
 * :feature:`259` Add humanize and robotize support for 1536w
 * :feature:`258` Add time_constraints value to the Protocol attributes

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -373,9 +373,6 @@ class TestRefify(object):
                 }
             ],
         }
-        # if refs or instructions is empty, raise error
-        with pytest.raises(RuntimeError):
-            dummy_protocol.as_dict()
         a = dummy_protocol.ref("test", cont_type="96-flat", discard=True)
         dummy_protocol.incubate(a, "ambient", "5:minute")
         # time_constraints is not serialized if empty


### PR DESCRIPTION
There are downstream libraries which call as_dict() for empty
refs/instructions. Since this is now a breaking change, choosing to
revert that change and slate it for 8.x.x