### PR TITLE
feat: Add harness support for units specified in ASC-51

### DIFF
--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -220,10 +220,14 @@ def convert_param(protocol, val, type_desc):
                 f"improperly formatted."
             )
     elif type in [
-        "volume",
-        "time",
-        "length",
+        "amount_concentration",
         "frequency",
+        "length",
+        "mass_concentration",
+        "time",
+        "volume",
+        "volume_concentration",
+        # TODO: Deprecate the following two types in next major release
         "concentration(mass)",
         "concentration(molar)",
     ]:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`265` Add support for mass_concentration, amount_concentration and volume_concentration, as specified in ASC-51
 * :support:`267` Pin black version to reduce CI/local inconsistencies. Pin to 20.8b1
 
 * :release:`7.1.1 <2020-07-21>`


### PR DESCRIPTION
ASC-51 added formal support for concentration units (amount, mass,
volume) into the Autoprotocol spec.

This adds support for these units into the harness, keeping to a similar
namespace.

Note that support for `concentration(mass)`, `concentration(molar)`
should be deprecated in some future major version bump.