### PR TITLE
style: Pin black to 20.8b1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     -   id: black
         language_version: python3.6

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -37,8 +37,7 @@ from .util import parse_unit, is_valid_well
 
 
 class InstructionBuilders(object):  # pylint: disable=too-few-public-methods
-    """General builders that apply to multiple instructions
-    """
+    """General builders that apply to multiple instructions"""
 
     def __init__(self):
         self.sbs_shapes = ["SBS96", "SBS384"]
@@ -1221,8 +1220,7 @@ class SpectrophotometryBuilders(InstructionBuilders):
 
 
 class LiquidHandleBuilders(InstructionBuilders):
-    """Builders for LiquidHandle Instructions
-    """
+    """Builders for LiquidHandle Instructions"""
 
     def __init__(self):
         super(LiquidHandleBuilders, self).__init__()
@@ -1861,8 +1859,7 @@ class LiquidHandleBuilders(InstructionBuilders):
 
 
 class PlateReaderBuilders(InstructionBuilders):
-    """Helpers for building parameters for plate reading instructions
-    """
+    """Helpers for building parameters for plate reading instructions"""
 
     def incubate_params(
         self, duration, shake_amplitude=None, shake_orbital=None, shaking=None
@@ -2060,8 +2057,7 @@ class EvaporateBuilders(InstructionBuilders):
 
 
 class GelPurifyBuilders(InstructionBuilders):
-    """Helpers for building GelPurify instructions
-    """
+    """Helpers for building GelPurify instructions"""
 
     def extract(self, source, band_list, lane=None, gel=None):
         """Helper for building extract params for gel_purify
@@ -2172,8 +2168,7 @@ class GelPurifyBuilders(InstructionBuilders):
 
 # pylint: disable=redefined-builtin
 class MagneticTransferBuilders(InstructionBuilders):
-    """Helpers for building MagneticTransfer instruction parameters
-    """
+    """Helpers for building MagneticTransfer instruction parameters"""
 
     @staticmethod
     def mag_dry(object, duration):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -13,9 +13,7 @@ from .constants import PROVISION_MEASUREMENT_MODES
 
 
 class Instruction(object):
-    """Base class for an instruction that is to later be encoded as JSON.
-
-    """
+    """Base class for an instruction that is to later be encoded as JSON."""
 
     builders = InstructionBuilders()
 

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -608,8 +608,7 @@ class Transfer(LiquidHandleMethod):
 
 
 class DryWellTransfer(Transfer):
-    """Dispenses while tracking liquid without mix_after
-    """
+    """Dispenses while tracking liquid without mix_after"""
 
     def __init__(
         self,
@@ -638,8 +637,7 @@ class DryWellTransfer(Transfer):
 
 
 class PreMixBlowoutTransfer(Transfer):
-    """Adds an additional blowout before the mix_after step
-    """
+    """Adds an additional blowout before the mix_after step"""
 
     def __init__(
         self,

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -4251,7 +4251,7 @@ class Protocol(object):
         ValueError
             If volumes are not correctly formatted or present.
 
-      """
+        """
         sources = []
         controls = []
         if not isinstance(samples, list):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :support:`267` Pin black version to reduce CI/local inconsistencies. Pin to 20.8b1
+
 * :release:`7.1.1 <2020-07-21>`
 * :bug:`261` Revert empty Protocol assertion check in `as_dict()`
 

--- a/test/instruction_test.py
+++ b/test/instruction_test.py
@@ -45,15 +45,21 @@ class TestBaseInstruction(object):
             [dict(some_bool=True, empty=[])]
         )
 
-        assert Instruction(
-            op="some instruction",
-            data={"not_empty": {"foo": "bar"}, "empty": {"foo": None, "bar": None}},
-        ).data == {"not_empty": {"foo": "bar"}}
+        assert (
+            Instruction(
+                op="some instruction",
+                data={"not_empty": {"foo": "bar"}, "empty": {"foo": None, "bar": None}},
+            ).data
+            == {"not_empty": {"foo": "bar"}}
+        )
 
-        assert Instruction(
-            op="some instruction",
-            data={"not_empty": ["foo", "bar"], "empty": [None, None]},
-        ).data == {"not_empty": ["foo", "bar"]}
+        assert (
+            Instruction(
+                op="some instruction",
+                data={"not_empty": ["foo", "bar"], "empty": [None, None]},
+            ).data
+            == {"not_empty": ["foo", "bar"]}
+        )
 
     @staticmethod
     def test_op(test_instruction):

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -168,7 +168,11 @@ class TestLiquidClassTransferMultiChannel(LiquidHandleTester):
     def test_fails_on_sbs384_transfer_in_sbs96_plate(self):
         with pytest.raises(ValueError):
             self.p.transfer(
-                self.flat.well(0), self.flat.well(0), "20:uL", rows=16, columns=24,
+                self.flat.well(0),
+                self.flat.well(0),
+                "20:uL",
+                rows=16,
+                columns=24,
             )
 
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -158,7 +158,9 @@ class TestThermocycle(object):
             [
                 {
                     "cycles": 1,
-                    "steps": [{"temperature": "95:celsius", "duration": "60:second"},],
+                    "steps": [
+                        {"temperature": "95:celsius", "duration": "60:second"},
+                    ],
                 },
                 {
                     "cycles": 30,
@@ -255,7 +257,9 @@ class TestThermocycle(object):
         groups = [
             {
                 "cycles": 1,
-                "steps": [{"temperature": "95:celsius", "duration": "60:second"},],
+                "steps": [
+                    {"temperature": "95:celsius", "duration": "60:second"},
+                ],
             }
         ]
         p = Protocol()


### PR DESCRIPTION
Previously we were running black on `stable`, but this occasionally led
to local/CI discrepancies when the cache is utilized. Pinning it can
help reduce these issues.