### PR TITLE
build: Fix Travis deployment issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   - python: '3.6'
     env: TOXENV=lint
   - python: '3.6'
-    env: TOXENV=clean,py36,stats_xml
+    env: TOXENV=clean,py36,stats_xml DEPLOY=true
   - python: '3.7'
     env: TOXENV=py37
   - python: '3.8'
@@ -40,8 +40,9 @@ deploy:
     secure: 'AAUOGNKdh2QaTeD0BzcDcNkgA4vomSlodDxkpblXucnXkUVyQJQ8akJlGACogE6xqZ4NgLrK9cOsHO5wQyQvWKsxZSY1/c2IrKxG1Ml4X7o3kB4J/a2tERghVPQe6z/Q2rqJN6WPrWvW4k3zj7AZ8X/54H5A/u4T7scEtaIo+Cg='
   on:
     repo: autoprotocol/autoprotocol-python
+    tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'
 - provider: pypi
   skip_cleanup: true
   username: '__token__'
@@ -50,4 +51,4 @@ deploy:
   on:
     tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :support:`-` Update travis.yml structure to fix deployment issue
+* :support:`269` Update travis.yml to trigger deployment only once
 
 * :release:`7.2.0 <2020-09-15>`
 * :feature:`265` Add support for mass_concentration, amount_concentration and volume_concentration, as specified in ASC-51

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :support:`-` Update travis.yml structure to fix deployment issue
+
 * :release:`7.2.0 <2020-09-15>`
 * :feature:`265` Add support for mass_concentration, amount_concentration and volume_concentration, as specified in ASC-51
 * :support:`267` Pin black version to reduce CI/local inconsistencies. Pin to 20.8b1


### PR DESCRIPTION
We're currently spinning off multiple build jobs for all tests running
python 3.6.

We should only be spinning off a single deployment job, adding an
additional envvar filter for that.