### PR TITLE
acoustic transfer: raise an error if no transfers are generated

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1178,17 +1178,17 @@ class Protocol(object):
             if v > Unit(0, "microliter"):
                 transfers.append(xfer)
 
-        for x in transfers:
-            x["volume"] = round(x["volume"].to("nl"), max_decimal_places)
-
-        if transfers:
-            return self._append_and_return(
-                AcousticTransfer([{"transfer": transfers}], droplet_size)
-            )
-        else:
+        if not transfers:
             raise RuntimeError(
                 "At least one transfer must have a nonzero transfer volume."
             )
+
+        for x in transfers:
+            x["volume"] = round(x["volume"].to("nl"), max_decimal_places)
+
+        return self._append_and_return(
+            AcousticTransfer([{"transfer": transfers}], droplet_size)
+        )
 
     def illuminaseq(
         self,

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1181,9 +1181,14 @@ class Protocol(object):
         for x in transfers:
             x["volume"] = round(x["volume"].to("nl"), max_decimal_places)
 
-        return self._append_and_return(
-            AcousticTransfer([{"transfer": transfers}], droplet_size)
-        )
+        if transfers:
+            return self._append_and_return(
+                AcousticTransfer([{"transfer": transfers}], droplet_size)
+            )
+        else:
+            raise RuntimeError(
+                "At least one transfer must have a nonzero transfer volume."
+            )
 
     def illuminaseq(
         self,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`270` 0 uL acoustic transfer raises an error instead of creating empty 'groups' field
 * :support:`269` Update travis.yml to trigger deployment only once
 
 * :release:`7.2.0 <2020-09-15>`


### PR DESCRIPTION
avoid situations where 0 uL transfers result in an empty "groups" field in autoprotocol and therefore cause an error when submitted to web. This change will cause the error to occur upstream of a web submission, notifying the protocol writer to avoid generating acoustic transfer instructions with 0 volume