### PR TITLE
build: Fix Travis bash syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     repo: autoprotocol/autoprotocol-python
     tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && $DEPLOY = true'
 - provider: pypi
   skip_cleanup: true
   username: '__token__'
@@ -51,4 +51,4 @@ deploy:
   on:
     tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && $DEPLOY = true'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug: `277` Fix travis.yml deployment syntax
+
 * :release:`7.4.0 <2020-10-28>`
 * :feature:`276` Add 96-flat-white-dc container type
 * :bug:`275` Fix acoustic transfer `one_source` bug to take dead volume into account.


### PR DESCRIPTION
Travis uses bash syntax for conditionals instead of its usual expressions syntax. See https://docs.travis-ci.com/user/deployment#conditional-releases-with-on

Tested this on a test repository.