### PR TITLE
Build: Release v7.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
-        language_version: python3.7
+        language_version: python3.6
 -   repo: https://github.com/pycqa/pylint
     rev: pylint-2.5.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/pycqa/pylint
     rev: pylint-2.5.2
     hooks:

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "7.4.0"
+__version__ = "7.4.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`7.4.1 <2020-11-19>`
 * :bug: `277` Fix travis.yml deployment syntax
 * :bug:`270 major` 0 uL acoustic transfer raises an error instead of creating empty 'groups' field
 


### PR DESCRIPTION
* :bug: `277` Fix travis.yml deployment syntax
* :bug:`270 major` 0 uL acoustic transfer raises an error instead of creating empty 'groups' field
