### PR TITLE
feat: Support Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`283` Support Python 3.9
 * :support:`282` migrate CI from travis to GitHub actions
 * :support:`281` Add downloads badge to track package usage
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py36, py37, py38, stats, lint, docs
+envlist = clean, py36, py37, py38, py39, stats, lint, docs
 
 [testenv]
 deps = .[test]


### PR DESCRIPTION
There are no obvious regressions for Python 3.9. Checking this in to our
test suite so that we can be notified of any future regressions.