### PR TITLE
style: Automatically sort imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+profile = black
+atomic = true
+include_trailing_comma = true
+lines_after_imports = 2
+lines_between_types = 1
+use_parentheses = true
+src_paths = ["autoprotocol", "test"]
+filter_files = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
     hooks:
     -   id: black
         language_version: python3.6
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
 -   repo: https://github.com/pycqa/pylint
     rev: pylint-2.5.2
     hooks:

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -25,15 +25,14 @@ Instruction
 """
 
 from collections import defaultdict
-from numbers import Number
-
 from collections.abc import Iterable  # pylint: disable=no-name-in-module
 from functools import reduce
+from numbers import Number
 
 from .constants import SBS_FORMAT_SHAPES
-from .container import WellGroup, Well, Container
+from .container import Container, Well, WellGroup
 from .unit import Unit
-from .util import parse_unit, is_valid_well
+from .util import is_valid_well, parse_unit
 
 
 class InstructionBuilders(object):  # pylint: disable=too-few-public-methods

--- a/autoprotocol/constants.py
+++ b/autoprotocol/constants.py
@@ -8,6 +8,7 @@ Constants used in protocol design, specification, and checking
 """
 from .unit import Unit
 
+
 SBS_FORMAT_SHAPES = {
     "SBS24": {"rows": 4, "columns": 6},
     "SBS96": {"rows": 8, "columns": 12},

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -13,6 +13,7 @@ import warnings
 from .constants import SBS_FORMAT_SHAPES
 from .unit import Unit
 
+
 SEAL_TYPES = ["ultra-clear", "foil", "breathable"]
 COVER_TYPES = ["standard", "low_evaporation", "universal"]
 

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -7,9 +7,9 @@ Container-type object and associated functions
 
 """
 
-from collections import namedtuple
-
 import re
+
+from collections import namedtuple
 
 from .container import Well
 from .unit import Unit

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -7,15 +7,15 @@ Module containing the harness module which helps with Manifest interpretation
 
 """
 
-import json
-
 import argparse
 import io
+import json
 
 from . import UserError
 from .container import WellGroup
 from .protocol import Protocol
 from .unit import Unit, UnitError
+
 
 _DYE_TEST_RS = {"dye4000": "rs18qmhr7t9jwq", "water": "rs17gmh5wafm5p"}
 

--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -20,10 +20,10 @@ When creating a vendor-specific library it's likely desirable to monkey patch
 `LiquidHandleMethod._get_tip_types` to reference TipTypes that the vendor
 supports.
 """
-from .tip_type import TipType
 from ..instruction import LiquidHandle
 from ..unit import Unit
 from ..util import parse_unit
+from .tip_type import TipType
 
 
 # pylint: disable=too-many-public-methods,protected-access

--- a/autoprotocol/liquid_handle/mix.py
+++ b/autoprotocol/liquid_handle/mix.py
@@ -7,10 +7,10 @@ movements within individual wells.
         for more details.
     :license: BSD, see LICENSE for more details
 """
-from .transfer import LiquidHandleMethod
 from ..instruction import LiquidHandle
 from ..unit import Unit
 from ..util import parse_unit
+from .transfer import LiquidHandleMethod
 
 
 # pylint: disable=protected-access

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -7,10 +7,10 @@
 Base LiquidHandleMethod used by Protocol.transfer to generate a series of
 movements between pairs of wells.
 """
-from .liquid_handle_method import LiquidHandleMethod
 from ..instruction import LiquidHandle
 from ..unit import Unit
 from ..util import parse_unit
+from .liquid_handle_method import LiquidHandleMethod
 
 
 # pylint: disable=unused-argument,too-many-instance-attributes,protected-access

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -10,12 +10,12 @@ Module containing the main `Protocol` object and associated functions
 import warnings
 
 from .constants import AGAR_CLLD_THRESHOLD, SPREAD_PATH
-from .container import Container, Well, SEAL_TYPES, COVER_TYPES
-from .container_type import ContainerType, _CONTAINER_TYPES
+from .container import COVER_TYPES, SEAL_TYPES, Container, Well
+from .container_type import _CONTAINER_TYPES, ContainerType
 from .instruction import *  # pylint: disable=unused-wildcard-import
-from .liquid_handle import Transfer, Mix, LiquidClass
+from .liquid_handle import LiquidClass, Mix, Transfer
 from .unit import Unit, UnitError
-from .util import _validate_as_instance, _check_container_type_with_shape
+from .util import _check_container_type_with_shape, _validate_as_instance
 
 
 class Ref(object):

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -9,9 +9,9 @@ Module containing a Units library
 
 from collections import defaultdict
 from decimal import Decimal, InvalidOperation
+from math import ceil, floor
 from numbers import Number
 
-from math import ceil, floor
 from pint import UnitRegistry
 from pint.errors import UndefinedUnitError
 from pint.quantity import _Quantity

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`284` add isort for automatic import sorting
 * :support:`286` CodeCov action for GitHub actions
 * :support:`285` use readme.rst for long description
 * :feature:`283` Support Python 3.9

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,9 +8,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+
 from datetime import datetime
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
+
 # Load version
 exec(open("autoprotocol/version.py").read())  # pylint: disable=exec-used
 

--- a/test/builder_test.py
+++ b/test/builder_test.py
@@ -1,17 +1,18 @@
 # pragma pylint: disable=missing-docstring
 
 import pytest
+
+from autoprotocol import Unit, Well
+from autoprotocol.builders import InstructionBuilders
 from autoprotocol.instruction import (
-    Thermocycle,
-    Dispense,
-    Spectrophotometry,
-    Evaporate,
     SPE,
+    Dispense,
+    Evaporate,
     FlowCytometry,
     Instruction,
+    Spectrophotometry,
+    Thermocycle,
 )
-from autoprotocol.builders import InstructionBuilders
-from autoprotocol import Unit, Well
 from autoprotocol.unit import UnitError
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,10 @@
 # pragma pylint: disable=missing-docstring
 import pytest
+
 from autoprotocol.container import Container
 from autoprotocol.container_type import ContainerType
-from autoprotocol.unit import Unit
 from autoprotocol.protocol import Protocol
+from autoprotocol.unit import Unit
 
 
 @pytest.fixture(scope="function")

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1,6 +1,7 @@
 # pragma pylint: disable=missing-docstring,protected-access
 # pragma pylint: disable=attribute-defined-outside-init,no-self-use
 import pytest
+
 from autoprotocol.container import Container, Well, WellGroup
 from autoprotocol.instruction import Instruction
 from autoprotocol.unit import Unit

--- a/test/cover_test.py
+++ b/test/cover_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from autoprotocol.protocol import Protocol
 
 

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from autoprotocol import UserError
 
 

--- a/test/instruction_test.py
+++ b/test/instruction_test.py
@@ -1,6 +1,7 @@
-from autoprotocol import Unit
-from autoprotocol.instruction import Instruction, Dispense
 import pytest
+
+from autoprotocol import Unit
+from autoprotocol.instruction import Dispense, Instruction
 
 
 # pylint: disable=protected-access

--- a/test/liquid_handle_builder_test.py
+++ b/test/liquid_handle_builder_test.py
@@ -1,8 +1,9 @@
 # pragma pylint: disable=missing-docstring,no-self-use
 # pragma pylint: disable=too-few-public-methods, attribute-defined-outside-init
 import pytest
-from autoprotocol.instruction import LiquidHandle
+
 from autoprotocol import Unit
+from autoprotocol.instruction import LiquidHandle
 
 
 class TestInstructionBuilders(object):

--- a/test/liquid_handle_integration_test.py
+++ b/test/liquid_handle_integration_test.py
@@ -1,9 +1,10 @@
 # pragma pylint: disable=missing-docstring, no-self-use, invalid-name
 # pragma pylint: disable=too-few-public-methods, attribute-defined-outside-init
 import pytest
-from autoprotocol.unit import Unit
+
+from autoprotocol.liquid_handle import DryWellTransfer, Mix
 from autoprotocol.protocol import Protocol
-from autoprotocol.liquid_handle import Mix, DryWellTransfer
+from autoprotocol.unit import Unit
 
 
 class LiquidHandleTester(object):

--- a/test/liquid_handle_unit_test.py
+++ b/test/liquid_handle_unit_test.py
@@ -2,15 +2,16 @@
 # pragma pylint: disable=too-few-public-methods, attribute-defined-outside-init
 # pragma pylint: disable=protected-access
 import pytest
+
 from autoprotocol import Unit
-from autoprotocol.liquid_handle.tip_type import TipType
-from autoprotocol.liquid_handle import LiquidHandleMethod, Transfer, Mix
+from autoprotocol.instruction import LiquidHandle
+from autoprotocol.liquid_handle import LiquidHandleMethod, Mix, Transfer
 from autoprotocol.liquid_handle.liquid_class import (
     LiquidClass,
     VolumeCalibration,
     VolumeCalibrationBin,
 )
-from autoprotocol.instruction import LiquidHandle
+from autoprotocol.liquid_handle.tip_type import TipType
 
 
 class LiquidClassTester(object):

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -1,12 +1,14 @@
-import pytest
-from autoprotocol.harness import (
-    ProtocolInfo,
-    Manifest,
-    seal_on_store,
-    get_protocol_preview,
-)
-from autoprotocol import Protocol, Unit, Well, WellGroup
 import json
+
+import pytest
+
+from autoprotocol import Protocol, Unit, Well, WellGroup
+from autoprotocol.harness import (
+    Manifest,
+    ProtocolInfo,
+    get_protocol_preview,
+    seal_on_store,
+)
 
 
 class TestManifest(object):

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -1,28 +1,30 @@
 # pragma pylint: disable=missing-docstring,protected-access
 # pragma pylint: disable=attribute-defined-outside-init
+import warnings
+
 import pytest
+
 from autoprotocol.container import Container, Well, WellGroup
 from autoprotocol.container_type import _CONTAINER_TYPES
+from autoprotocol.harness import (
+    _add_dye_to_preview_refs,
+    _convert_dispense_instructions,
+    _convert_provision_instructions,
+)
 from autoprotocol.instruction import (
-    Thermocycle,
-    Incubate,
-    Spin,
-    Dispense,
-    GelPurify,
-    Fluorescence,
-    Absorbance,
-    Luminescence,
-    Instruction,
     SPE,
+    Absorbance,
+    Dispense,
+    Fluorescence,
+    GelPurify,
+    Incubate,
+    Instruction,
+    Luminescence,
+    Spin,
+    Thermocycle,
 )
 from autoprotocol.protocol import Protocol, Ref
 from autoprotocol.unit import Unit, UnitError
-from autoprotocol.harness import (
-    _add_dye_to_preview_refs,
-    _convert_provision_instructions,
-    _convert_dispense_instructions,
-)
-import warnings
 
 
 class TestProtocolMultipleExist(object):

--- a/test/provision_test.py
+++ b/test/provision_test.py
@@ -1,5 +1,7 @@
 import json
+
 from test.test_util import TestUtils
+
 import pytest
 
 from autoprotocol.protocol import Protocol

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -1,6 +1,8 @@
-import pytest
-from autoprotocol.unit import Unit, UnitValueError
 from decimal import Decimal
+
+import pytest
+
+from autoprotocol.unit import Unit, UnitValueError
 
 
 class TestUnitType(object):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from autoprotocol.util import parse_unit
 from autoprotocol.unit import Unit
+from autoprotocol.util import parse_unit
 
 
 class TestParseUnit(object):

--- a/test/well_test.py
+++ b/test/well_test.py
@@ -1,6 +1,8 @@
 # pragma pylint: disable=missing-docstring,attribute-defined-outside-init
 import warnings
+
 import pytest
+
 from autoprotocol.container import Container
 
 


### PR DESCRIPTION
Adds an isort dependency for automatic import sorting. This is purely a
non-functional quality-of-life change.