### PR TITLE
support: Add long description

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`285` use readme.rst for long description
 * :feature:`283` Support Python 3.9
 * :support:`282` migrate CI from travis to GitHub actions
 * :support:`281` Add downloads badge to track package usage

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
     url="https://github.com/autoprotocol/autoprotocol-python",
     maintainer="The Autoprotocol Development Team",
     description="Python library for generating Autoprotocol",
+    long_description=open("README.rst").read(),
+    long_description_content_type="text/x-rst",
     license="BSD",
     maintainer_email="support@strateos.com",
     version=__version__,  # pylint: disable=undefined-variable


### PR DESCRIPTION
Our current pypi page has no long_description,
see https://pypi.org/project/autoprotocol/

Let's use our current README to populate that field.