### PR TITLE
build: Add CodeCov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,13 @@ jobs:
       if: ${{matrix.python-version != 3.6 }}
 
     - name: Run Tox with coverage
-      run: tox -e clean,py
+      run: tox -e clean,py,stats_xml
+      if: ${{ matrix.python-version == 3.6 }}
+
+    - name: Upload to CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
       if: ${{ matrix.python-version == 3.6 }}
 
   docs:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`286` CodeCov action for GitHub actions
 * :support:`285` use readme.rst for long description
 * :feature:`283` Support Python 3.9
 * :support:`282` migrate CI from travis to GitHub actions


### PR DESCRIPTION
The migration to GitHub actions did not include the previous CodeCov
functionality. This adds it in.