### PR TITLE
feat: Add informatics attribute to Instruction

### DIFF
--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -27,7 +27,7 @@ class Informatics:
         pass
 
     @abstractmethod
-    def validate(self, data):
+    def validate(self):
         pass
 
 

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -108,9 +108,7 @@ class AttachCompounds(Informatics):
             )
 
         if not isinstance(self.compounds, list):
-            raise TypeError(
-                f"compounds: {self.compounds} must be provided in a list."
-            )
+            raise TypeError(f"compounds: {self.compounds} must be provided in a list.")
         for compd in self.compounds:
             if not isinstance(compd, Compound):
                 raise TypeError(f"compound: {compd} must be Compound type.")

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -8,6 +8,7 @@ Contains all the Autoprotocol Informatics objects
 """
 
 from abc import abstractmethod
+
 from .compound import Compound
 from .container import Container, WellGroup
 from .util import is_valid_well
@@ -18,6 +19,7 @@ class Informatics:
     Base class for informatics attribute in an instruction that is to later be
     encoded as JSON.
     """
+
     def __init__(self):
         pass
 
@@ -56,12 +58,11 @@ class AttachCompounds(Informatics):
     TypeError
         each element in compounds must be Compound type
     """
+
     def __init__(self, data: dict, all_wells):
         # turn data into specific attributes for this type of informatics
         if not isinstance(data, dict):
-            raise TypeError(
-                f"informatics data: {data} must be provided in a dict."
-            )
+            raise TypeError(f"informatics data: {data} must be provided in a dict.")
 
         self.wells = data["wells"]
         self.compounds = data["compounds"]
@@ -85,34 +86,32 @@ class AttachCompounds(Informatics):
 
         # validate compounds
         if not isinstance(self.compounds, list):
-            raise TypeError(
-                f"compounds: {self.compounds} must be provided in a list."
-            )
+            raise TypeError(f"compounds: {self.compounds} must be provided in a list.")
         for compd in self.compounds:
             if not isinstance(compd, Compound):
                 raise TypeError(f"compound: {compd} must be Compound type.")
 
     def as_dict(self):
         """generates a Python object representation of Informatics attribute in
-           class Instruction
+        class Instruction
 
-            Returns
-            -------
-            dict
-                a dict of python objects that have the same structure as the
-                Autoprotocol JSON for the Informatics
+         Returns
+         -------
+         dict
+             a dict of python objects that have the same structure as the
+             Autoprotocol JSON for the Informatics
 
-            Notes
-            -----
-            Used as a part of JSON serialization of the Instruction
+         Notes
+         -----
+         Used as a part of JSON serialization of the Instruction
 
-            See Also
-            --------
-            :class:`Instruction` : Instruction class
+         See Also
+         --------
+         :class:`Instruction` : Instruction class
 
-         """
+        """
 
         return {
             "type": "attach_compounds",
-            "data": {"wells": self.wells, "compounds": self.compounds}
+            "data": {"wells": self.wells, "compounds": self.compounds},
         }

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -1,0 +1,118 @@
+"""
+Contains all the Autoprotocol Informatics objects
+
+    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+        for more details.
+    :license: BSD, see LICENSE for more details
+
+"""
+
+from abc import abstractmethod
+from .compound import Compound
+from .container import Container, WellGroup
+from .util import is_valid_well
+
+
+class Informatics:
+    """
+    Base class for informatics attribute in an instruction that is to later be
+    encoded as JSON.
+    """
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def as_dict(self):
+        pass
+
+
+class AttachCompounds(Informatics):
+    """
+    informatics type attach_compounds is constructed as a list of dict detailing
+    new compounds
+
+    Parameters
+    ----------
+    data:
+        dict of informatics data
+    all_wells: WellGroup
+        All wells used in the instruction that are applicable for attach_compounds
+        to take effect on.
+
+    Returns
+    -------
+    AttachCompounds
+
+    Raises
+    ------
+    TypeError
+        data must be a dict
+    TypeError
+        wells must be Well, list of Well, or WellGroup
+    ValueError
+        wells must be part of wells or containers instruction operates on
+    TypeError
+        compounds must be a list
+    TypeError
+        each element in compounds must be Compound type
+    """
+    def __init__(self, data: dict, all_wells):
+        # turn data into specific attributes for this type of informatics
+        if not isinstance(data, dict):
+            raise TypeError(
+                f"informatics data: {data} must be provided in a dict."
+            )
+
+        self.wells = data["wells"]
+        self.compounds = data["compounds"]
+
+        # validate wells
+        if not is_valid_well(self.wells):
+            raise TypeError(
+                f"wells: {self.wells} must be Well, list of Well or WellGroup."
+            )
+        wells = WellGroup(self.wells)
+        # wells must be one or more of the wells or container instruction is operating on.
+        if isinstance(all_wells, Container):
+            all_wells = all_wells.all_wells()
+        else:
+            all_wells = WellGroup(all_wells)
+        for well in wells.wells:
+            if well not in all_wells.wells:
+                raise ValueError(
+                    f"informatics well: {wells} must be one of the wells used in this instruction."
+                )
+
+        # validate compounds
+        if not isinstance(self.compounds, list):
+            raise TypeError(
+                f"compounds: {self.compounds} must be provided in a list."
+            )
+        for compd in self.compounds:
+            if not isinstance(compd, Compound):
+                raise TypeError(f"compound: {compd} must be Compound type.")
+
+    def as_dict(self):
+        """generates a Python object representation of Informatics attribute in
+           class Instruction
+
+            Returns
+            -------
+            dict
+                a dict of python objects that have the same structure as the
+                Autoprotocol JSON for the Informatics
+
+            Notes
+            -----
+            Used as a part of JSON serialization of the Instruction
+
+            See Also
+            --------
+            :class:`Instruction` : Instruction class
+
+         """
+
+        return {
+            "type": "attach_compounds",
+            "data": {"wells": self.wells, "compounds": self.compounds}
+        }

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -27,7 +27,7 @@ class Informatics:
         pass
 
     @abstractmethod
-    def validate(self, all_wells):
+    def validate(self, data):
         pass
 
 
@@ -61,7 +61,7 @@ class AttachCompounds(Informatics):
 
         self.wells = data["wells"]
         self.compounds = data["compounds"]
-
+        self.validate()
         super().__init__()
 
     def as_dict(self):
@@ -93,16 +93,6 @@ class AttachCompounds(Informatics):
         """
         validate input dict has valid parameters to instantiate AttachCompounds
 
-        Parameters
-        ----------
-        data: dict
-            Informatics data
-
-        Returns
-        -------
-        data: dict
-            Validated dict of data
-
         Raises
         ------
         TypeError
@@ -118,7 +108,9 @@ class AttachCompounds(Informatics):
             )
 
         if not isinstance(self.compounds, list):
-            raise TypeError(f"compounds: {self.compounds} must be provided in a list.")
+            raise TypeError(
+                f"compounds: {self.compounds} must be provided in a list."
+            )
         for compd in self.compounds:
             if not isinstance(compd, Compound):
                 raise TypeError(f"compound: {compd} must be Compound type.")

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -91,6 +91,8 @@ class AttachCompounds(Informatics):
             if not isinstance(compd, Compound):
                 raise TypeError(f"compound: {compd} must be Compound type.")
 
+        super().__init__()
+
     def as_dict(self):
         """generates a Python object representation of Informatics attribute in
         class Instruction

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -38,29 +38,20 @@ class AttachCompounds(Informatics):
 
     Parameters
     ----------
-    data: dict
-        dict of Informatics data
-
+    wells: Well, list(Well) or WellGroup
+        wells where compounds are associated with
+    compounds: list(Compound)
+        List of new compounds attached to wells
     Returns
     -------
     AttachCompounds
 
-    Raises
-    ------
-    TypeError
-        data must be a dict
-    TypeError
-        wells must be Well, list of Well, or WellGroup
-    TypeError
-        compounds must be a list
-    TypeError
-        each element in compounds must be Compound type
     """
 
-    def __init__(self, data: dict):
+    def __init__(self, wells, compounds):
 
-        self.wells = data["wells"]
-        self.compounds = data["compounds"]
+        self.wells = wells
+        self.compounds = compounds
         self.validate()
         super().__init__()
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -10,6 +10,7 @@ Contains all the Autoprotocol Instruction objects
 # pragma pylint: disable=too-few-public-methods, redefined-builtin
 from .builders import *  # pylint: disable=unused-wildcard-import
 from .constants import PROVISION_MEASUREMENT_MODES
+from .informatics import Informatics
 
 
 class Instruction(object):
@@ -19,16 +20,14 @@ class Instruction(object):
 
     def __init__(self, op, data, informatics=None):
         super(Instruction, self).__init__()
-        if informatics is None:
-            informatics = []
+        # if informatics is None:
+        #     informatics = []
         self.op = op
         self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)
         self.informatics = self._remove_empty_fields(
             self._remove_empty_fields(informatics)
         )
-        if len(informatics) > 0:
-            self.__dict__.update(self.informatics)
 
     def __repr__(self):
         return f"Instruction({self.op}, {self.data}, {self.informatics})"
@@ -1384,7 +1383,7 @@ class Provision(Instruction):
       Destination(s) for specified resource, together with volume information
     measurement_mode : str
       Measurement mode. Possible values are :py:class:`autoprotocol.constants.MEASUREMENT_MODES`
-    informatics : list(dict)
+    informatics : list(Informatics)
       List of expected aliquot effects at the completion of this instruction
 
     Raises
@@ -1401,7 +1400,7 @@ class Provision(Instruction):
 
     """
 
-    def __init__(self, resource_id, dests, measurement_mode="volume", informatics=None):
+    def __init__(self, resource_id, dests, measurement_mode="volume", informatics: Informatics = None):
         if measurement_mode not in PROVISION_MEASUREMENT_MODES:
             raise RuntimeError(
                 f"{measurement_mode} is not a valid measurement mode for provisioning"
@@ -1414,7 +1413,7 @@ class Provision(Instruction):
                 "measurement_mode": measurement_mode,
                 "to": dests,
             },
-            informatics={"informatics": informatics},
+            informatics=informatics,
         )
 
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -28,7 +28,6 @@ class Instruction(object):
             self._remove_empty_fields(informatics)
         )
         if len(informatics) > 0:
-            # self._verify_informatics_field(self.informatics)
             self.__dict__.update(self.informatics)
 
     def __repr__(self):
@@ -97,80 +96,6 @@ class Instruction(object):
                 if not filter_criteria(_)
             ]
         return data
-
-    # @staticmethod
-    # def _verify_informatics_field(informatics):
-    #     """
-    #     Helper function to verify that informatics dict has a valid type
-    #     and data schema
-    #
-    #     Parameters
-    #     ----------
-    #     informatics: list
-    #         list of dict with informatics type and data
-    #
-    #     Returns
-    #     -------
-    #     List
-    #         Validated list of dict with informatics details
-    #
-    #     Raises
-    #     ------
-    #     TypeError
-    #         informatics must be provided in a list
-    #     TypeError
-    #         informatics element must be in dict
-    #     ValueError
-    #         informaticss dict must have correct keys
-    #     ValueError
-    #         informatics type must be a valid type
-    #     TypeError
-    #         informatics data must be provided in dict
-    #     ValueError
-    #         each informatics type must have correct keys to describe its data
-    #
-    #     """
-    #     # any informatics dict must only have these keys.
-    #     valid_informatics_keys = ["type", "data"]
-    #     # informatics have a list of valid types, and data schema specific for each type.
-    #     # Here, each key represents a valid `type`, and value is a list of valid
-    #     # keys for its `data`.
-    #     valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
-    #
-    #     # informatics must be a list of dict.
-    #     if isinstance(informatics, list):
-    #         for info in informatics:
-    #             if not isinstance(info, dict):
-    #                 raise TypeError(f"informatics: {info} must be provided in a dict.")
-    #     else:
-    #         raise TypeError(
-    #             f"informatics: {informatics} must be provided in a list of dict. "
-    #         )
-    #
-    #     for info in informatics:
-    #         info_keys = info.keys()
-    #         if set(info_keys) != set(valid_informatics_keys):
-    #             raise ValueError(
-    #                 f"informatics dict: {info} must have keys: {valid_informatics_keys}"
-    #             )
-    #         info_type = info["type"]
-    #         info_data = info["data"]
-    #         if info_type not in valid_informatics_types.keys():
-    #             raise ValueError(
-    #                 f"informatics type: {info_type} must be one of {valid_informatics_types.keys()}"
-    #             )
-    #         if not isinstance(info_data, dict):
-    #             raise TypeError(
-    #                 f"informatics data: {info_data} must be provided in a dict."
-    #             )
-    #         valid_data_keys = valid_informatics_types[info_type]
-    #         if set(info_data.keys()) != set(valid_data_keys):
-    #             raise ValueError(
-    #                 f"informatics type: {info_type} must have a data dict with valid "
-    #                 f"keys: {valid_data_keys}."
-    #             )
-    #
-    #     return informatics
 
 
 class MagneticTransfer(Instruction):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -20,8 +20,6 @@ class Instruction(object):
 
     def __init__(self, op, data, informatics=None):
         super(Instruction, self).__init__()
-        # if informatics is None:
-        #     informatics = []
         self.op = op
         self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -10,7 +10,8 @@ Contains all the Autoprotocol Instruction objects
 # pragma pylint: disable=too-few-public-methods, redefined-builtin
 from .builders import *  # pylint: disable=unused-wildcard-import
 from .constants import PROVISION_MEASUREMENT_MODES
-from .informatics import Informatics
+from .container import Container
+from .informatics import AttachCompounds, Informatics
 
 
 class Instruction(object):
@@ -20,12 +21,17 @@ class Instruction(object):
 
     def __init__(self, op, data, informatics=None):
         super(Instruction, self).__init__()
+        if informatics is None:
+            informatics = []
         self.op = op
         self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)
         self.informatics = self._remove_empty_fields(
             self._remove_empty_fields(informatics)
         )
+
+        if len(self.informatics) > 0:
+            self._set_informatics()
 
     def __repr__(self):
         return f"Instruction({self.op}, {self.data}, {self.informatics})"
@@ -93,6 +99,117 @@ class Instruction(object):
                 if not filter_criteria(_)
             ]
         return data
+
+    def _set_informatics(self):
+        """
+        set Instruction informatics to valid list of Informatics
+
+        Raises
+        ------
+        TypeError
+            informatics must be a list
+        TypeError
+            informatics element must be a dict
+        KeyError
+            informatics must have keys 'type' and 'data'
+        ValueError
+            informatics type must be a valid type
+        """
+        # any informatics dict must only have these keys.
+        valid_informatics_keys = ["type", "data"]
+        # informatics must be a list of dict.
+        informatics = self.informatics
+        if isinstance(informatics, list):
+            for info in informatics:
+                if not isinstance(info, dict):
+                    raise TypeError(f"informatics: {info} must be provided in a dict.")
+        else:
+            raise TypeError(
+                f"informatics: {informatics} must be provided in a list of dict. "
+            )
+
+        # instantiate Informatics based on the type
+        valid_informatics = []
+        for info in self.informatics:
+            info_keys = info.keys()
+            if set(info_keys) != set(valid_informatics_keys):
+                raise KeyError(
+                    f"informatics dict: {info} must have keys: {valid_informatics_keys}"
+                )
+            # validate wells only if `wells` param is present in informatics
+            try:
+                if info["data"]["wells"]:
+                    self._check_info_wells()
+            except KeyError:
+                continue
+            info_type = info["type"]
+            if info_type == "attach_compounds":
+                info_obj = AttachCompounds(info["data"])
+            else:
+                raise ValueError(f"informatics type: {info_type} is not a valid type.")
+            valid_informatics.append(info_obj)
+
+        self.informatics = valid_informatics
+
+    def _check_info_wells(self):
+        """
+        validates Informatics wells are included in the wells associated with
+        the instruction.
+
+        Raises
+        -------
+        TypeError
+            wells are Well, list of Well or WellGroup
+        ValueError
+            Informatics wells are part of wells Instruction is operating on
+        """
+        for info in self.informatics:
+            info_wells = info["data"]["wells"]
+            if not is_valid_well(info_wells):
+                raise TypeError(
+                    f"wells: {info_wells} must be Well, list of Well or WellGroup."
+                )
+            wells = WellGroup(info_wells)
+
+            available_wells = self.get_wells(self.data)
+            for well in wells.wells:
+                if well not in available_wells:
+                    raise ValueError(
+                        f"informatics well: {wells} must be one of the wells used in this instruction."
+                    )
+
+    def get_wells(self, op_data):
+        """
+        Parameters
+        ----------
+        op_data: dict
+            Instruction data containing all the operational parameters
+
+        Returns
+        -------
+        list(Well)
+            List of all wells associated with the instruction. Note this contains
+            all source and destination wells for instructions such as `liquid_handle`.
+        """
+        all_wells = []
+        if type(op_data) is dict:
+            for k, v in op_data.items():
+                all_wells.append(self.get_wells(v))
+        elif type(op_data) is list:
+            for i in op_data:
+                all_wells.extend([self.get_wells(i)])
+        # if container is provided, all wells in the container are included
+        elif type(op_data) is Container:
+            all_wells.append(op_data.all_wells())
+        elif is_valid_well(op_data):
+            all_wells.append(WellGroup(op_data))
+
+        flattened_wells = [item for sublist in all_wells for item in sublist]
+        # remove any duplicate values in the list
+        unique_wells = []
+        [unique_wells.append(x) for x in flattened_wells if x not in unique_wells]
+
+        return unique_wells
 
 
 class MagneticTransfer(Instruction):
@@ -1398,7 +1515,7 @@ class Provision(Instruction):
 
     """
 
-    def __init__(self, resource_id, dests, measurement_mode="volume", informatics: Informatics = None):
+    def __init__(self, resource_id, dests, measurement_mode="volume", informatics=None):
         if measurement_mode not in PROVISION_MEASUREMENT_MODES:
             raise RuntimeError(
                 f"{measurement_mode} is not a valid measurement mode for provisioning"

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -142,13 +142,12 @@ class Instruction(object):
             for info in informatics:
                 if not isinstance(info, dict):
                     raise TypeError(f"informatics: {info} must be provided in a dict.")
-            info_list = informatics
         else:
             raise TypeError(
                 f"informatics: {informatics} must be provided in a list of dict. "
             )
 
-        for info in info_list:
+        for info in informatics:
             info_keys = info.keys()
             if set(info_keys) != set(valid_informatics_keys):
                 raise ValueError(
@@ -171,7 +170,7 @@ class Instruction(object):
                     f"keys: {valid_data_keys}."
                 )
 
-        return info_list
+        return informatics
 
 
 class MagneticTransfer(Instruction):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -28,7 +28,7 @@ class Instruction(object):
             self._remove_empty_fields(informatics)
         )
         if len(informatics) > 0:
-            self._verify_informatics_field(self.informatics)
+            # self._verify_informatics_field(self.informatics)
             self.__dict__.update(self.informatics)
 
     def __repr__(self):
@@ -98,79 +98,79 @@ class Instruction(object):
             ]
         return data
 
-    @staticmethod
-    def _verify_informatics_field(informatics):
-        """
-        Helper function to verify that informatics dict has a valid type
-        and data schema
-
-        Parameters
-        ----------
-        informatics: list
-            list of dict with informatics type and data
-
-        Returns
-        -------
-        List
-            Validated list of dict with informatics details
-
-        Raises
-        ------
-        TypeError
-            informatics must be provided in a list
-        TypeError
-            informatics element must be in dict
-        ValueError
-            informaticss dict must have correct keys
-        ValueError
-            informatics type must be a valid type
-        TypeError
-            informatics data must be provided in dict
-        ValueError
-            each informatics type must have correct keys to describe its data
-
-        """
-        # any informatics dict must only have these keys.
-        valid_informatics_keys = ["type", "data"]
-        # informatics have a list of valid types, and data schema specific for each type.
-        # Here, each key represents a valid `type`, and value is a list of valid
-        # keys for its `data`.
-        valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
-
-        # informatics must be a list of dict.
-        if isinstance(informatics, list):
-            for info in informatics:
-                if not isinstance(info, dict):
-                    raise TypeError(f"informatics: {info} must be provided in a dict.")
-        else:
-            raise TypeError(
-                f"informatics: {informatics} must be provided in a list of dict. "
-            )
-
-        for info in informatics:
-            info_keys = info.keys()
-            if set(info_keys) != set(valid_informatics_keys):
-                raise ValueError(
-                    f"informatics dict: {info} must have keys: {valid_informatics_keys}"
-                )
-            info_type = info["type"]
-            info_data = info["data"]
-            if info_type not in valid_informatics_types.keys():
-                raise ValueError(
-                    f"informatics type: {info_type} must be one of {valid_informatics_types.keys()}"
-                )
-            if not isinstance(info_data, dict):
-                raise TypeError(
-                    f"informatics data: {info_data} must be provided in a dict."
-                )
-            valid_data_keys = valid_informatics_types[info_type]
-            if set(info_data.keys()) != set(valid_data_keys):
-                raise ValueError(
-                    f"informatics type: {info_type} must have a data dict with valid "
-                    f"keys: {valid_data_keys}."
-                )
-
-        return informatics
+    # @staticmethod
+    # def _verify_informatics_field(informatics):
+    #     """
+    #     Helper function to verify that informatics dict has a valid type
+    #     and data schema
+    #
+    #     Parameters
+    #     ----------
+    #     informatics: list
+    #         list of dict with informatics type and data
+    #
+    #     Returns
+    #     -------
+    #     List
+    #         Validated list of dict with informatics details
+    #
+    #     Raises
+    #     ------
+    #     TypeError
+    #         informatics must be provided in a list
+    #     TypeError
+    #         informatics element must be in dict
+    #     ValueError
+    #         informaticss dict must have correct keys
+    #     ValueError
+    #         informatics type must be a valid type
+    #     TypeError
+    #         informatics data must be provided in dict
+    #     ValueError
+    #         each informatics type must have correct keys to describe its data
+    #
+    #     """
+    #     # any informatics dict must only have these keys.
+    #     valid_informatics_keys = ["type", "data"]
+    #     # informatics have a list of valid types, and data schema specific for each type.
+    #     # Here, each key represents a valid `type`, and value is a list of valid
+    #     # keys for its `data`.
+    #     valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
+    #
+    #     # informatics must be a list of dict.
+    #     if isinstance(informatics, list):
+    #         for info in informatics:
+    #             if not isinstance(info, dict):
+    #                 raise TypeError(f"informatics: {info} must be provided in a dict.")
+    #     else:
+    #         raise TypeError(
+    #             f"informatics: {informatics} must be provided in a list of dict. "
+    #         )
+    #
+    #     for info in informatics:
+    #         info_keys = info.keys()
+    #         if set(info_keys) != set(valid_informatics_keys):
+    #             raise ValueError(
+    #                 f"informatics dict: {info} must have keys: {valid_informatics_keys}"
+    #             )
+    #         info_type = info["type"]
+    #         info_data = info["data"]
+    #         if info_type not in valid_informatics_types.keys():
+    #             raise ValueError(
+    #                 f"informatics type: {info_type} must be one of {valid_informatics_types.keys()}"
+    #             )
+    #         if not isinstance(info_data, dict):
+    #             raise TypeError(
+    #                 f"informatics data: {info_data} must be provided in a dict."
+    #             )
+    #         valid_data_keys = valid_informatics_types[info_type]
+    #         if set(info_data.keys()) != set(valid_data_keys):
+    #             raise ValueError(
+    #                 f"informatics type: {info_type} must have a data dict with valid "
+    #                 f"keys: {valid_data_keys}."
+    #             )
+    #
+    #     return informatics
 
 
 class MagneticTransfer(Instruction):
@@ -1459,6 +1459,8 @@ class Provision(Instruction):
       Destination(s) for specified resource, together with volume information
     measurement_mode : str
       Measurement mode. Possible values are :py:class:`autoprotocol.constants.MEASUREMENT_MODES`
+    informatics : list(dict)
+      List of expected aliquot effects at the completion of this instruction
 
     Raises
     ------
@@ -1474,7 +1476,7 @@ class Provision(Instruction):
 
     """
 
-    def __init__(self, resource_id, dests, measurement_mode="volume"):
+    def __init__(self, resource_id, dests, measurement_mode="volume", informatics=None):
         if measurement_mode not in PROVISION_MEASUREMENT_MODES:
             raise RuntimeError(
                 f"{measurement_mode} is not a valid measurement mode for provisioning"
@@ -1487,6 +1489,7 @@ class Provision(Instruction):
                 "measurement_mode": measurement_mode,
                 "to": dests,
             },
+            informatics={"informatics": informatics},
         )
 
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -52,7 +52,7 @@ class Instruction(object):
 
         """
         # informatics is not serialized if empty.
-        if getattr(self, "informatics"):
+        if self.informatics:
             return dict(op=self.op, **self.data, informatics=self.informatics)
         else:
             return dict(op=self.op, **self.data)

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -17,14 +17,22 @@ class Instruction(object):
 
     builders = InstructionBuilders()
 
-    def __init__(self, op, data):
+    def __init__(self, op, data, informatics=None):
         super(Instruction, self).__init__()
+        if informatics is None:
+            informatics = []
         self.op = op
         self.data = self._remove_empty_fields(self._remove_empty_fields(data))
         self.__dict__.update(self.data)
+        self.informatics = self._remove_empty_fields(
+            self._remove_empty_fields(informatics)
+        )
+        if len(informatics) > 0:
+            self._verify_informatics_field(self.informatics)
+            self.__dict__.update(self.informatics)
 
     def __repr__(self):
-        return f"Instruction({self.op}, {self.data})"
+        return f"Instruction({self.op}, {self.data}, {self.informatics})"
 
     def _as_AST(self):
         """generates a Python object representation of Autoprotocol JSON
@@ -44,7 +52,11 @@ class Instruction(object):
         :meth:`Protocol._refify` : Protocol serialization method
 
         """
-        return dict(op=self.op, **self.data)
+        # informatics is not serialized if empty.
+        if getattr(self, "informatics"):
+            return dict(op=self.op, **self.data, informatics=self.informatics)
+        else:
+            return dict(op=self.op, **self.data)
 
     @staticmethod
     def _remove_empty_fields(data):
@@ -85,6 +97,85 @@ class Instruction(object):
                 if not filter_criteria(_)
             ]
         return data
+
+    @staticmethod
+    def _verify_informatics_field(informatics):
+        """
+        Helper function to verify that informatics dict has a valid type
+        and data schema
+
+        Parameters
+        ----------
+        informatics: list
+            list of dict with informatics type and data
+
+        Returns
+        -------
+        List
+            Validated list of dict with informatics details
+
+        Raises
+        ------
+        TypeError
+            informatics must be provided in a list
+        TypeError
+            informatics element must be in dict
+        ValueError
+            informaticss dict must have correct keys
+        ValueError
+            informatics type must be a valid type
+        TypeError
+            informatics data must be provided in dict
+        ValueError
+            each informatics type must have correct keys to describe its data
+
+        """
+        # any informatics dict must only have these keys.
+        valid_informatics_keys = ["type", "data"]
+        # informatics have a list of valid types, and data schema specific for each type.
+        # Here, each key represents a valid `type`, and value is a list of valid
+        # keys for its `data`.
+        valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
+
+        # if informatics is provided in a dict, format it to a list of dict.
+        # if isinstance(informatics, dict):
+        #     info_list = []
+        #     info_list.append(informatics)
+        # if informatics is provided in a list, it must be a list of dict.
+        if isinstance(informatics, list):
+            for info in informatics:
+                if not isinstance(info, dict):
+                    raise TypeError(f"informatics: {info} must be provided in a dict.")
+            info_list = informatics
+        else:
+            raise TypeError(
+                f"informatics: {informatics} must be provided in a list of dict. "
+            )
+
+        for info in info_list:
+            info_keys = info.keys()
+            if set(info_keys) != set(valid_informatics_keys):
+                raise ValueError(
+                    f"informatics dict: {info} must have keys: {valid_informatics_keys}"
+                )
+            info_type = info["type"]
+            info_data = info["data"]
+            if info_type not in valid_informatics_types.keys():
+                raise ValueError(
+                    f"informatics type: {info_type} must be one of {valid_informatics_types.keys()}"
+                )
+            if not isinstance(info_data, dict):
+                raise TypeError(
+                    f"informatics data: {info_data} must be provided in a dict."
+                )
+            valid_data_keys = valid_informatics_types[info_type]
+            if set(info_data.keys()) != set(valid_data_keys):
+                raise ValueError(
+                    f"informatics type: {info_type} must have a data dict with valid "
+                    f"keys: {valid_data_keys}."
+                )
+
+        return info_list
 
 
 class MagneticTransfer(Instruction):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -11,7 +11,7 @@ Contains all the Autoprotocol Instruction objects
 from .builders import *  # pylint: disable=unused-wildcard-import
 from .constants import PROVISION_MEASUREMENT_MODES
 from .container import Container
-from .informatics import AttachCompounds, Informatics
+from .informatics import AttachCompounds
 
 
 class Instruction(object):
@@ -178,6 +178,8 @@ class Instruction(object):
                         f"informatics well: {wells} must be one of the wells used in this instruction."
                     )
 
+    # pragma pylint: disable=expression-not-assigned
+    # pragma pylint: disable=unused-variable
     def get_wells(self, op_data):
         """
         Parameters

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -137,11 +137,7 @@ class Instruction(object):
         # keys for its `data`.
         valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
 
-        # if informatics is provided in a dict, format it to a list of dict.
-        # if isinstance(informatics, dict):
-        #     info_list = []
-        #     info_list.append(informatics)
-        # if informatics is provided in a list, it must be a list of dict.
+        # informatics must be a list of dict.
         if isinstance(informatics, list):
             for info in informatics:
                 if not isinstance(info, dict):

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -101,58 +101,6 @@ class Instruction(object):
             ]
         return data
 
-    # def _set_informatics(self):
-    #     """
-    #     set Instruction informatics to valid list of Informatics
-    #
-    #     Raises
-    #     ------
-    #     TypeError
-    #         informatics must be a list
-    #     TypeError
-    #         informatics element must be a dict
-    #     KeyError
-    #         informatics must have keys 'type' and 'data'
-    #     ValueError
-    #         informatics type must be a valid type
-    #     """
-    # any informatics dict must only have these keys.
-    # valid_informatics_keys = ["type", "data"]
-    # # informatics must be a list of dict.
-    # informatics = self.informatics
-    # if isinstance(informatics, list):
-    #     for info in informatics:
-    #         if not isinstance(info, dict):
-    #             raise TypeError(f"informatics: {info} must be provided in a dict.")
-    # else:
-    #     raise TypeError(
-    #         f"informatics: {informatics} must be provided in a list of dict. "
-    #     )
-
-    # instantiate Informatics based on the type
-    # valid_informatics = []
-    # for info in self.informatics:
-    #     info_keys = info.keys()
-    #     if set(info_keys) != set(valid_informatics_keys):
-    #         raise KeyError(
-    #             f"informatics dict: {info} must only have keys: {valid_informatics_keys}"
-    #         )
-    # validate wells only if `wells` param is present in informatics
-    # try:
-    #     if info["data"]["wells"]:
-    #         self._check_info_wells()
-    # except KeyError:
-    #     continue
-    # info_type = info["type"]
-    #     if info_type == "attach_compounds":
-    #         info_obj = AttachCompounds(info["data"]["wells"], info["data"]["compounds"])
-    #         self._check_info_wells()
-    #     else:
-    #         raise ValueError(f"informatics type: {info_type} is not a valid type.")
-    #     valid_informatics.append(info_obj)
-    #
-    # self.informatics = valid_informatics
-
     def _check_informatics(self):
         """
         Validates each Informatics element in informatics.

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5999,6 +5999,8 @@ class Protocol(object):
             return self._refify(op_data._as_AST())
         elif isinstance(op_data, Ref):
             return op_data.opts
+        elif isinstance(op_data, Compound):
+            return op_data.InChI
         else:
             return op_data
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -682,7 +682,7 @@ class Protocol(object):
         TypeError
             informatics element must be in dict
         KeyError
-            informaticss dict must have correct keys
+            informatics dict must have correct keys
         ValueError
             informatics type must be a valid type
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -659,34 +659,34 @@ class Protocol(object):
     @staticmethod
     def check_informatics(informatics, wells):
         """
-                Helper function to verify that informatics dict has a valid type
-                and data schema
+        Helper function to verify that informatics dict has a valid type
+        and data schema
 
-                Parameters
-                ----------
-                informatics: list
-                    list of dict with informatics type and data
-                all_wells: WellGroup
-                    All wells used in the instruction that are applicable for informatics
-                    to take effect on.
+        Parameters
+        ----------
+        informatics: list
+            list of dict with informatics type and data
+        all_wells: WellGroup
+            All wells used in the instruction that are applicable for informatics
+            to take effect on.
 
-                Returns
-                -------
-                List
-                    Validated list of dict with informatics details
+        Returns
+        -------
+        List
+            Validated list of dict with informatics details
 
-                Raises
-                ------
-                TypeError
-                    informatics must be provided in a list
-                TypeError
-                    informatics element must be in dict
-                KeyError
-                    informaticss dict must have correct keys
-                ValueError
-                    informatics type must be a valid type
+        Raises
+        ------
+        TypeError
+            informatics must be provided in a list
+        TypeError
+            informatics element must be in dict
+        KeyError
+            informaticss dict must have correct keys
+        ValueError
+            informatics type must be a valid type
 
-                """
+        """
         # any informatics dict must only have these keys.
         valid_informatics_keys = ["type", "data"]
         # informatics must be a list of dict.
@@ -710,9 +710,7 @@ class Protocol(object):
             if info_type == "attach_compounds":
                 info_obj = AttachCompounds(info["data"], wells)
             else:
-                raise ValueError(
-                    f"informatics type: {info_type} is not a valid type."
-                )
+                raise ValueError(f"informatics type: {info_type} is not a valid type.")
             valid_informatics.append(info_obj.as_dict())
 
         return valid_informatics

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -9,6 +9,7 @@ Module containing the main `Protocol` object and associated functions
 
 import warnings
 
+from .compound import Compound
 from .constants import AGAR_CLLD_THRESHOLD, SPREAD_PATH
 from .container import COVER_TYPES, SEAL_TYPES, Container, Well
 from .container_type import _CONTAINER_TYPES, ContainerType
@@ -653,6 +654,112 @@ class Protocol(object):
         if instruction_index < 0:
             raise ValueError("Instruction index less than 0")
         return instruction_index
+
+    @staticmethod
+    def check_informatics_field(informatics, all_wells):
+        """
+        Helper function to verify that informatics dict has a valid type
+        and data schema
+
+        Parameters
+        ----------
+        informatics: list
+            list of dict with informatics type and data
+        all_wells: WellGroup
+            All wells used in the instruction that are applicable for informatics
+            to take effect on.
+
+        Returns
+        -------
+        List
+            Validated list of dict with informatics details
+
+        Raises
+        ------
+        TypeError
+            informatics must be provided in a list
+        TypeError
+            informatics element must be in dict
+        KeyError
+            informaticss dict must have correct keys
+        ValueError
+            informatics type must be a valid type
+        TypeError
+            informatics data must be provided in dict
+        KeyError
+            each informatics type must have correct keys to describe its data
+        TypeError
+            wells must be Well, list of Well or GroupWell
+        TypeError
+            compounds must be a list
+        TypeError
+            compound must be Compound
+
+        """
+        # any informatics dict must only have these keys.
+        valid_informatics_keys = ["type", "data"]
+        # informatics have a list of valid types, and data schema specific for each type.
+        # Here, each key represents a valid `type`, and value is a list of valid
+        # keys for its `data`.
+        valid_informatics_types = {"attach_compounds": ["wells", "compounds"]}
+
+        # informatics must be a list of dict.
+        if isinstance(informatics, list):
+            for info in informatics:
+                if not isinstance(info, dict):
+                    raise TypeError(f"informatics: {info} must be provided in a dict.")
+        else:
+            raise TypeError(
+                f"informatics: {informatics} must be provided in a list of dict. "
+            )
+
+        for info in informatics:
+            info_keys = info.keys()
+            if set(info_keys) != set(valid_informatics_keys):
+                raise KeyError(
+                    f"informatics dict: {info} must have keys: {valid_informatics_keys}"
+                )
+            info_type = info["type"]
+            info_data = info["data"]
+            if info_type not in valid_informatics_types.keys():
+                raise ValueError(
+                    f"informatics type: {info_type} must be one of {valid_informatics_types.keys()}"
+                )
+            if not isinstance(info_data, dict):
+                raise TypeError(
+                    f"informatics data: {info_data} must be provided in a dict."
+                )
+            valid_data_keys = valid_informatics_types[info_type]
+            if set(info_data.keys()) != set(valid_data_keys):
+                raise KeyError(
+                    f"informatics type: {info_type} must have a data dict with valid "
+                    f"keys: {valid_data_keys}."
+                )
+            # verify data values for each informatics type
+            if info_type == "attach_compounds":
+                wells = info_data["wells"]
+                compounds = info_data["compounds"]
+                if not is_valid_well(wells):
+                    raise TypeError(
+                        f"wells: {info_data['wells']} must be Well, list of Well or WellGroup."
+                    )
+                wells = WellGroup(wells)
+                all_wells = WellGroup(all_wells)
+                for well in wells.wells:
+                    if well not in all_wells.wells:
+                        raise ValueError(
+                            f"informatics well: {wells} must be one of the wells used in this instruction."
+                        )
+                info_data["wells"] = wells
+                if not isinstance(compounds, list):
+                    raise TypeError(
+                        f"compounds: {compounds} must be provided in a list."
+                    )
+                for compd in compounds:
+                    if not isinstance(compd, Compound):
+                        raise TypeError(f"compound: {compd} must be Compound type.")
+
+        return informatics
 
     def _append_and_return(self, instructions):
         """
@@ -5050,7 +5157,9 @@ class Protocol(object):
         """
         return self._append_and_return(ImagePlate(ref, mode, dataref))
 
-    def provision(self, resource_id, dests, amounts=None, volumes=None):
+    def provision(
+        self, resource_id, dests, amounts=None, volumes=None, informatics=None
+    ):
         """
         Provision a commercial resource from a catalog into the specified
         destination well(s).  A new tip is used for each destination well
@@ -5076,6 +5185,9 @@ class Protocol(object):
           one should be specified explicitly in a list matching the order of the
           specified destinations.
           Note:  Volumes and amounts arguments are mutually exclusive. Only one is required
+        informatics: list
+          List of dict detailing aliquot effects intended from this instruction. Valid type
+          and data schema for this field is found in Instrucion.
 
         Raises
         ------
@@ -5137,6 +5249,9 @@ class Protocol(object):
 
         measurement_mode = self._identify_provision_mode(provision_amounts)
 
+        if informatics is not None:
+            self.check_informatics_field(informatics, dests)
+
         provision_instructions_to_return: Provision = []
         for d, amount in zip(dests, provision_amounts):
             if d.container.is_covered() or d.container.is_sealed():
@@ -5180,7 +5295,9 @@ class Protocol(object):
             else:
                 provision_instructions_to_return.append(
                     self._append_and_return(
-                        Provision(resource_id, dest_group, measurement_mode)
+                        Provision(
+                            resource_id, dest_group, measurement_mode, informatics
+                        )
                     )
                 )
         return provision_instructions_to_return

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5182,6 +5182,8 @@ class Protocol(object):
                 and self.instructions[-1].resource_id == resource_id
                 and self.instructions[-1].to[-1]["well"].container == d.container
             ):
+                if informatics is not None:
+                    self.instructions[-1].informatics.extend(informatics)
                 self.instructions[-1].to.append(xfer)
             else:
                 provision_instructions_to_return.append(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -666,7 +666,7 @@ class Protocol(object):
         ----------
         informatics: list
             list of dict with informatics type and data
-        all_wells: WellGroup
+        wells: WellGroup
             All wells used in the instruction that are applicable for informatics
             to take effect on.
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -744,7 +744,12 @@ class Protocol(object):
                         f"wells: {info_data['wells']} must be Well, list of Well or WellGroup."
                     )
                 wells = WellGroup(wells)
-                all_wells = WellGroup(all_wells)
+                # if instruction is executed on ref (Container) unit instead of Well, check against all
+                # wells in the container.
+                if isinstance(all_wells, Container):
+                    all_wells = all_wells.all_wells()
+                else:
+                    all_wells = WellGroup(all_wells)
                 for well in wells.wells:
                     if well not in all_wells.wells:
                         raise ValueError(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -13,6 +13,7 @@ from .compound import Compound
 from .constants import AGAR_CLLD_THRESHOLD, SPREAD_PATH
 from .container import COVER_TYPES, SEAL_TYPES, Container, Well
 from .container_type import _CONTAINER_TYPES, ContainerType
+from .informatics import Informatics
 from .instruction import *  # pylint: disable=unused-wildcard-import
 from .liquid_handle import LiquidClass, Mix, Transfer
 from .unit import Unit, UnitError

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -5080,9 +5080,8 @@ class Protocol(object):
           one should be specified explicitly in a list matching the order of the
           specified destinations.
           Note:  Volumes and amounts arguments are mutually exclusive. Only one is required
-        informatics: list(dict)
-          List of dict detailing aliquot effects intended from this instruction. Valid type
-          and data schema for this field is found in Instrucion.
+        informatics: list(Informatics)
+          List of Informatics detailing aliquot effects intended from this instruction.
 
         Raises
         ------
@@ -5889,7 +5888,7 @@ class Protocol(object):
         elif isinstance(op_data, Compound):
             return op_data.InChI
         elif isinstance(op_data, Informatics):
-            return op_data.as_dict()
+            return self._refify(op_data.as_dict())
         else:
             return op_data
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`290` Add informatics attribute to Instruction
+
 * :release:`7.5.0 <2021-01-31>`
 * :feature:`288` Add "Compound" to derived types
 * :support:`284` add isort for automatic import sorting

--- a/test/informatics_test.py
+++ b/test/informatics_test.py
@@ -13,26 +13,22 @@ class TestAttachCompoundsInformatics(object):
         p = Protocol()
         cont1 = p.ref("cont_1", None, "96-flat", discard=True)
         well1 = cont1.well(0)
-        comp = Compound("InChI=1S/CH4/h1H4")
+        well2 = cont1.well(1)
+        wg1 = WellGroup([well1, well2])
+        comp1 = Compound("InChI=1S/CH4/h1H4")
+        comp2 = Compound("InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3")
 
-        assert AttachCompounds({"wells": well1, "compounds": [comp]}).compounds == [
-            comp
-        ]
-        assert AttachCompounds({"wells": well1, "compounds": [comp]}).wells == well1
-        with pytest.raises(TypeError):
-            AttachCompounds("foo")
-        with pytest.raises(KeyError):
-            AttachCompounds({"foo": well1, "compounds": [comp]})
-        with pytest.raises(KeyError):
-            AttachCompounds({"wells": well1, "bar": [comp]})
+        assert AttachCompounds(well1, [comp1]).compounds == [comp1]
+        assert AttachCompounds(well1, [comp1]).wells == well1
+        assert AttachCompounds(wg1, [comp1, comp2]).compounds == [comp1, comp2]
+        assert AttachCompounds(wg1, [comp1, comp2]).wells == wg1
 
     def test_as_dict(self):
         p = Protocol()
         cont1 = p.ref("cont_1", None, "96-flat", discard=True)
         well1 = WellGroup([cont1.well(0)])
         comp = Compound("InChI=1S/CH4/h1H4")
-        example_informatics = {"wells": well1, "compounds": [comp]}
-        assert AttachCompounds(example_informatics).as_dict() == {
+        assert AttachCompounds(well1, [comp]).as_dict() == {
             "type": "attach_compounds",
             "data": {"wells": well1, "compounds": [comp]},
         }
@@ -43,8 +39,8 @@ class TestAttachCompoundsInformatics(object):
         well1 = WellGroup([cont1.well(0)])
         comp = Compound("InChI=1S/CH4/h1H4")
         with pytest.raises(TypeError):
-            AttachCompounds({"wells": "foo", "compounds": [comp]}).validate()
+            AttachCompounds(well1, comp)
         with pytest.raises(TypeError):
-            AttachCompounds({"wells": well1, "compounds": comp}).validate()
+            AttachCompounds("foo", [comp])
         with pytest.raises(TypeError):
-            AttachCompounds({"wells": well1, "compounds": "foo"}).validate()
+            AttachCompounds(well1, "InChI=1S/CH4/h1H4")

--- a/test/informatics_test.py
+++ b/test/informatics_test.py
@@ -13,16 +13,12 @@ class TestAttachCompoundsInformatics(object):
         p = Protocol()
         cont1 = p.ref("cont_1", None, "96-flat", discard=True)
         well1 = cont1.well(0)
-        wg1 = WellGroup([cont1.well(0), cont1.well(1)])
-        wg2 = WellGroup([cont1.well(2), cont1.well(3)])
         comp = Compound("InChI=1S/CH4/h1H4")
 
-        assert AttachCompounds(
-            {"wells": well1, "compounds": [comp]}
-        ).compounds == [comp]
-        assert (
-            AttachCompounds({"wells": well1, "compounds": [comp]}).wells == well1
-        )
+        assert AttachCompounds({"wells": well1, "compounds": [comp]}).compounds == [
+            comp
+        ]
+        assert AttachCompounds({"wells": well1, "compounds": [comp]}).wells == well1
         with pytest.raises(TypeError):
             AttachCompounds("foo")
         with pytest.raises(KeyError):

--- a/test/informatics_test.py
+++ b/test/informatics_test.py
@@ -18,25 +18,17 @@ class TestAttachCompoundsInformatics(object):
         comp = Compound("InChI=1S/CH4/h1H4")
 
         assert AttachCompounds(
-            {"wells": well1, "compounds": [comp]}, wg1
+            {"wells": well1, "compounds": [comp]}
         ).compounds == [comp]
         assert (
-            AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).wells == well1
+            AttachCompounds({"wells": well1, "compounds": [comp]}).wells == well1
         )
         with pytest.raises(TypeError):
-            AttachCompounds("foo", wg1)
+            AttachCompounds("foo")
         with pytest.raises(KeyError):
-            AttachCompounds({"foo": well1, "compounds": [comp]}, wg1)
+            AttachCompounds({"foo": well1, "compounds": [comp]})
         with pytest.raises(KeyError):
-            AttachCompounds({"wells": well1, "bar": [comp]}, wg1)
-        with pytest.raises(TypeError):
-            AttachCompounds({"wells": "cont_1/0", "compounds": [comp]}, wg1)
-        with pytest.raises(ValueError):
-            AttachCompounds({"wells": well1, "compounds": [comp]}, wg2)
-        with pytest.raises(TypeError):
-            AttachCompounds({"wells": well1, "compounds": comp}, wg1)
-        with pytest.raises(TypeError):
-            AttachCompounds({"wells": well1, "compounds": "foo"}, wg1)
+            AttachCompounds({"wells": well1, "bar": [comp]})
 
     def test_as_dict(self):
         p = Protocol()
@@ -44,7 +36,19 @@ class TestAttachCompoundsInformatics(object):
         well1 = WellGroup([cont1.well(0)])
         comp = Compound("InChI=1S/CH4/h1H4")
         example_informatics = {"wells": well1, "compounds": [comp]}
-        assert AttachCompounds(example_informatics, well1).as_dict() == {
+        assert AttachCompounds(example_informatics).as_dict() == {
             "type": "attach_compounds",
             "data": {"wells": well1, "compounds": [comp]},
         }
+
+    def test_validate(self):
+        p = Protocol()
+        cont1 = p.ref("cont_1", None, "96-flat", discard=True)
+        well1 = WellGroup([cont1.well(0)])
+        comp = Compound("InChI=1S/CH4/h1H4")
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": "foo", "compounds": [comp]}).validate()
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": well1, "compounds": comp}).validate()
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": well1, "compounds": "foo"}).validate()

--- a/test/informatics_test.py
+++ b/test/informatics_test.py
@@ -1,0 +1,49 @@
+# pragma pylint: disable=missing-docstring
+import pytest
+
+from autoprotocol.compound import Compound
+from autoprotocol.container import WellGroup
+from autoprotocol.informatics import AttachCompounds
+from autoprotocol.protocol import Protocol
+
+
+# pylint: disable=protected-access
+class TestAttachCompoundsInformatics(object):
+    def test_attach_compounds(self):
+        p = Protocol()
+        cont1 = p.ref("cont_1", None, "96-flat", discard=True)
+        well1 = cont1.well(0)
+        wg1 = WellGroup([cont1.well(0), cont1.well(1)])
+        wg2 = WellGroup([cont1.well(2), cont1.well(3)])
+        comp = Compound("InChI=1S/CH4/h1H4")
+
+        assert AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).compounds == [comp]
+        assert AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).wells == well1
+        with pytest.raises(TypeError):
+            AttachCompounds("foo", wg1)
+        with pytest.raises(KeyError):
+            AttachCompounds({"foo": well1, "compounds": [comp]}, wg1)
+        with pytest.raises(KeyError):
+            AttachCompounds({"wells": well1, "bar": [comp]}, wg1)
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": "cont_1/0", "compounds": [comp]}, wg1)
+        with pytest.raises(ValueError):
+            AttachCompounds({"wells": well1, "compounds": [comp]}, wg2)
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": well1, "compounds": comp}, wg1)
+        with pytest.raises(TypeError):
+            AttachCompounds({"wells": well1, "compounds": "foo"}, wg1)
+
+    def test_as_dict(self):
+        p = Protocol()
+        cont1 = p.ref("cont_1", None, "96-flat", discard=True)
+        well1 = WellGroup([cont1.well(0)])
+        comp = Compound("InChI=1S/CH4/h1H4")
+        example_informatics = {
+            "wells": well1,
+            "compounds": [comp]
+        }
+        assert AttachCompounds(example_informatics, well1).as_dict() == {
+            "type": "attach_compounds",
+            "data": {"wells": well1, "compounds": [comp]}
+        }

--- a/test/informatics_test.py
+++ b/test/informatics_test.py
@@ -17,8 +17,12 @@ class TestAttachCompoundsInformatics(object):
         wg2 = WellGroup([cont1.well(2), cont1.well(3)])
         comp = Compound("InChI=1S/CH4/h1H4")
 
-        assert AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).compounds == [comp]
-        assert AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).wells == well1
+        assert AttachCompounds(
+            {"wells": well1, "compounds": [comp]}, wg1
+        ).compounds == [comp]
+        assert (
+            AttachCompounds({"wells": well1, "compounds": [comp]}, wg1).wells == well1
+        )
         with pytest.raises(TypeError):
             AttachCompounds("foo", wg1)
         with pytest.raises(KeyError):
@@ -39,11 +43,8 @@ class TestAttachCompoundsInformatics(object):
         cont1 = p.ref("cont_1", None, "96-flat", discard=True)
         well1 = WellGroup([cont1.well(0)])
         comp = Compound("InChI=1S/CH4/h1H4")
-        example_informatics = {
-            "wells": well1,
-            "compounds": [comp]
-        }
+        example_informatics = {"wells": well1, "compounds": [comp]}
         assert AttachCompounds(example_informatics, well1).as_dict() == {
             "type": "attach_compounds",
-            "data": {"wells": well1, "compounds": [comp]}
+            "data": {"wells": well1, "compounds": [comp]},
         }

--- a/test/instruction_test.py
+++ b/test/instruction_test.py
@@ -32,7 +32,7 @@ class TestBaseInstruction(object):
                 "type": "attach_compounds",
                 "data": {
                     "wells": "foo/0",
-                    "compounds": ["1S/C6H6/c1-2-4-6-5-3-1/h1-6H"],
+                    "compounds": ["comp"],
                 },
             }
         ]
@@ -81,6 +81,20 @@ class TestBaseInstruction(object):
             == {"not_empty": ["foo", "bar"]}
         )
 
+        assert (
+            Instruction(
+                op="some instruction",
+                data={"some_param": "some_value"},
+                informatics=[
+                    {
+                        "type": "attach_compounds",
+                        "data": {"wells": "foo/1", "compounds": None},
+                    }
+                ],
+            ).informatics
+            == [{"type": "attach_compounds", "data": {"wells": "foo/1"}}]
+        )
+
     @staticmethod
     def test_op(test_instruction):
         assert test_instruction.op == "test_instruction"
@@ -101,74 +115,10 @@ class TestBaseInstruction(object):
                 "type": "attach_compounds",
                 "data": {
                     "wells": "foo/0",
-                    "compounds": ["1S/C6H6/c1-2-4-6-5-3-1/h1-6H"],
+                    "compounds": ["comp"],
                 },
             }
         ]
-
-    def test_verify_informatics_field(self):
-        assert Instruction(
-            op="some_instruction",
-            data={"some_field": "some_value"},
-            informatics=[
-                {
-                    "type": "attach_compounds",
-                    "data": {
-                        "wells": "foo/0",
-                        "compounds": ["1S/C6H6/c1-2-4-6-5-3-1/h1-6H"],
-                    },
-                }
-            ],
-        ).informatics == [
-            {
-                "type": "attach_compounds",
-                "data": {
-                    "wells": "foo/0",
-                    "compounds": ["1S/C6H6/c1-2-4-6-5-3-1/h1-6H"],
-                },
-            }
-        ]
-
-        with pytest.raises(ValueError):
-            Instruction(
-                op="some instruction",
-                data={"some_param": "some_value"},
-                informatics=[
-                    {
-                        "type": "attach_compounds",
-                        "data": {"wells": [], "compounds": None},
-                    }
-                ],
-            )
-
-        with pytest.raises(TypeError):
-            Instruction._verify_informatics_field(["foo", "bar"])
-        with pytest.raises(ValueError):
-            Instruction._verify_informatics_field(
-                [
-                    {
-                        "type": "foo",
-                        "data": {
-                            "wells": "foo/1",
-                            "compounds": ["1S/ClH.Na/h1H;/q;+1/p-1/i;1+1"],
-                        },
-                    }
-                ]
-            )
-        with pytest.raises(ValueError):
-            Instruction._verify_informatics_field(
-                [
-                    {
-                        "type": "attach_compounds",
-                    }
-                ]
-            )
-        with pytest.raises(ValueError):
-            Instruction._verify_informatics_field(
-                [{"type": "attach_compounds", "data": {"foo": "some_data"}}]
-            )
-        with pytest.raises(ValueError):
-            Instruction._verify_informatics_field([{"foo": "bar"}])
 
 
 class TestInstruction(object):

--- a/test/instruction_test.py
+++ b/test/instruction_test.py
@@ -85,14 +85,9 @@ class TestBaseInstruction(object):
             Instruction(
                 op="some instruction",
                 data={"some_param": "some_value"},
-                informatics=[
-                    {
-                        "type": "attach_compounds",
-                        "data": {"wells": "foo/1", "compounds": None},
-                    }
-                ],
+                informatics=[],
             ).informatics
-            == [{"type": "attach_compounds", "data": {"wells": "foo/1"}}]
+            == []
         )
 
     @staticmethod

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -598,17 +598,16 @@ class TestInformatics(object):
         p = dummy_protocol
         cont1 = p.ref("cont1", id=None, cont_type="96-flat", discard=True)
         well1 = cont1.well(0)
-        well2 = cont1.well(1)
         compd1 = Compound("InChI=1S/CH4/h1H4")
 
-        output = p.check_informatics_field(
+        output = p.check_informatics(
             [{"type": "attach_compounds", "data": {"wells": [well1], "compounds": [compd1]}}],
             cont1
         )
         assert output[0]["type"] == "attach_compounds"
 
         with pytest.raises(TypeError):
-            p.check_informatics_field(
+            p.check_informatics(
                 {
                     "type": "attach_compounds",
                     "data": {"wells": [well1], "compounds": [compd1]},
@@ -617,55 +616,9 @@ class TestInformatics(object):
             )
 
         with pytest.raises(ValueError):
-            p.check_informatics_field(
+            p.check_informatics(
                 [{"type": "foo", "data": {"wells": [well1], "compounds": [compd1]}}],
                 well1,
-            )
-
-        with pytest.raises(KeyError):
-            p.check_informatics_field([{"foo": "some value"}], well1)
-
-        with pytest.raises(TypeError):
-            p.check_informatics_field(
-                [{"type": "attach_compounds", "data": "some value"}], well1
-            )
-
-        with pytest.raises(TypeError):
-            p.check_informatics_field(
-                [
-                    {
-                        "type": "attach_compounds",
-                        "data": {"wells": "foo", "compounds": [compd1]},
-                    }
-                ],
-                well1,
-            )
-
-        with pytest.raises(TypeError):
-            p.check_informatics_field(
-                [
-                    {
-                        "type": "attach_compounds",
-                        "data": {"wells": well1, "compounds": ["foo"]},
-                    }
-                ],
-                well1,
-            )
-
-        with pytest.raises(KeyError):
-            p.check_informatics_field(
-                [{"type": "attach_compounds", "data": {"foo": "bar"}}], well1
-            )
-
-        with pytest.raises(ValueError):
-            p.check_informatics_field(
-                [
-                    {
-                        "type": "attach_compounds",
-                        "data": {"wells": well1, "compounds": [compd1]},
-                    }
-                ],
-                well2,
             )
 
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -601,8 +601,13 @@ class TestInformatics(object):
         compd1 = Compound("InChI=1S/CH4/h1H4")
 
         output = p.check_informatics(
-            [{"type": "attach_compounds", "data": {"wells": [well1], "compounds": [compd1]}}],
-            cont1
+            [
+                {
+                    "type": "attach_compounds",
+                    "data": {"wells": [well1], "compounds": [compd1]},
+                }
+            ],
+            cont1,
         )
         assert output[0]["type"] == "attach_compounds"
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -352,6 +352,17 @@ class TestRefify(object):
         # refify Ref
         assert p._refify(p.refs["test"]) == p.refs["test"].opts
 
+        # refify Compound
+        compd = Compound("InChI=1S/CH4/h1H4")
+        assert p._refify(compd) == "InChI=1S/CH4/h1H4"
+
+        # refify AttachCompouonds
+        ac = AttachCompounds(well, [compd])
+        assert p._refify(ac) == {
+            "type": "attach_compounds",
+            "data": {"wells": "test/0", "compounds": ["InChI=1S/CH4/h1H4"]},
+        }
+
         # refify other
         s = "randomstring"
         i = 24
@@ -2772,12 +2783,7 @@ class TestDyeTest(object):
             "rs181818181818",
             c1.well(1),
             volumes="10:microliter",
-            informatics=[
-                {
-                    "type": "attach_compounds",
-                    "data": {"wells": [c1.well(1)], "compounds": [compd1]},
-                }
-            ],
+            informatics=[AttachCompounds([c1.well(1)], [compd1])],
         )
         _convert_provision_instructions(p1, 3, 3)
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -2779,6 +2779,7 @@ class TestDyeTest(object):
         p1.provision("rs18s8x4qbsvjz", c1.well(0), volumes="10:microliter")
         p1.incubate(c1, where="ambient", duration="1:hour", uncovered=True)
         p1.provision("rs18s8x4qbsvjz", c1.well(0), volumes="10:microliter")
+        p1.provision("rs181818181818", c1.well(2), volumes="10:microliter")
         p1.provision(
             "rs181818181818",
             c1.well(1),
@@ -2792,6 +2793,31 @@ class TestDyeTest(object):
         assert p1.instructions[3].informatics == []
         assert isinstance(p1.instructions[4].informatics[0], AttachCompounds)
         assert p1.instructions[4].informatics[0].compounds == [compd1]
+
+        # when the same resource is transferred into the same container multiple times,
+        # transfer(s) are appended to 'to', and 'informatics' is extended.
+        p2 = Protocol()
+        p2.provision("rs123123123", c1.well(1), volumes="10:microliter")
+
+        assert len(p2.instructions[0].data["to"]) == 1
+        assert p2.instructions[0].informatics == []
+
+        p2.provision(
+            "rs123123123",
+            c1.well(2),
+            volumes="50:microliter",
+            informatics=[AttachCompounds([c1.well(1)], [compd1])],
+        )
+
+        assert len(p2.instructions) == 1
+        assert len(p2.instructions[0].data["to"]) == 2
+        assert len(p2.instructions[0].informatics) == 1
+        assert isinstance(p2.instructions[0].informatics[0], AttachCompounds)
+
+        p2.provision("rs123123123", c1.well(3), volumes="30:microliter")
+
+        assert len(p2.instructions[0].data["to"]) == 3
+        assert len(p2.instructions[0].informatics) == 1
 
         with pytest.raises(ValueError):
             _convert_provision_instructions(p1, "2", 3)

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -596,9 +596,16 @@ class TestTimeConstraints(object):
 class TestInformatics(object):
     def test_informatics_checker(self, dummy_protocol):
         p = dummy_protocol
-        well1 = p.ref("well1", id=None, cont_type="96-pcr", discard=True).well(0)
-        well2 = p.ref("well2", id=None, cont_type="96-pcr", discard=True).well(1)
+        cont1 = p.ref("cont1", id=None, cont_type="96-flat", discard=True)
+        well1 = cont1.well(0)
+        well2 = cont1.well(1)
         compd1 = Compound("InChI=1S/CH4/h1H4")
+
+        output = p.check_informatics_field(
+            [{"type": "attach_compounds", "data": {"wells": [well1], "compounds": [compd1]}}],
+            cont1
+        )
+        assert output[0]["type"] == "attach_compounds"
 
         with pytest.raises(TypeError):
             p.check_informatics_field(

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -594,61 +594,6 @@ class TestTimeConstraints(object):
         assert len(p.time_constraints) == 4
 
 
-class TestInformatics(object):
-    def test_informatics_checker(self, dummy_protocol):
-        p = dummy_protocol
-        cont1 = p.ref("cont1", id=None, cont_type="96-flat", discard=True)
-        well1 = cont1.well(0)
-        compd1 = Compound("InChI=1S/CH4/h1H4")
-
-        output = p.check_informatics(
-            [
-                {
-                    "type": "attach_compounds",
-                    "data": {"wells": [well1], "compounds": [compd1]},
-                }
-            ],
-            cont1,
-        )
-        assert isinstance(output[0], AttachCompounds)
-        assert output[0].wells == WellGroup([well1])
-        assert output[0].compounds == [compd1]
-
-        with pytest.raises(TypeError):
-            p.check_informatics(
-                {
-                    "type": "attach_compounds",
-                    "data": {"wells": [well1], "compounds": [compd1]},
-                },
-                well1,
-            )
-
-        with pytest.raises(ValueError):
-            p.check_informatics(
-                [{"type": "foo", "data": {"wells": [well1], "compounds": [compd1]}}],
-                well1,
-            )
-
-    def test_informatics_wells_checker(self, dummy_protocol):
-        p = dummy_protocol
-        cont1 = p.ref("cont1", id=None, cont_type="96-flat", discard=True)
-        cont2 = p.ref("cont2", id=None, cont_type="96-flat", discard=True)
-        well1 = cont1.well(0)
-        compd1 = Compound("InChI=1S/CH4/h1H4")
-
-        with pytest.raises(TypeError):
-            p.check_informatics(
-                [{"type": "attach_compounds", "data": {"wells": "foo", "compounds": [compd1]}}],
-                cont2,
-            )
-
-        with pytest.raises(ValueError):
-            p.check_informatics(
-                [{"type": "attach_compounds", "data": {"wells": [well1], "compounds": [compd1]}}],
-                cont2,
-            )
-
-
 class TestAbsorbance(object):
     def test_single_well(self):
         p = Protocol()
@@ -2838,7 +2783,7 @@ class TestDyeTest(object):
 
         assert p1.instructions[1].data["resource_id"] == "rs18s8x4qbsvjz"
         assert p1.instructions[3].data["resource_id"] == "rs17gmh5wafm5p"
-        assert p1.instructions[3].informatics is None
+        assert p1.instructions[3].informatics == []
         assert isinstance(p1.instructions[4].informatics[0], AttachCompounds)
         assert p1.instructions[4].informatics[0].compounds == [compd1]
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -2795,7 +2795,7 @@ class TestDyeTest(object):
         assert p1.instructions[4].informatics[0].compounds == [compd1]
 
         # when the same resource is transferred into the same container multiple times,
-        # transfer(s) are appended to 'to', and 'informatics' is extended.
+        # transfer(s) are appended to 'to', and 'informatics' is extended if there are any.
         p2 = Protocol()
         p2.provision("rs123123123", c1.well(1), volumes="10:microliter")
 
@@ -2806,7 +2806,7 @@ class TestDyeTest(object):
             "rs123123123",
             c1.well(2),
             volumes="50:microliter",
-            informatics=[AttachCompounds([c1.well(1)], [compd1])],
+            informatics=[AttachCompounds([c1.well(2)], [compd1])],
         )
 
         assert len(p2.instructions) == 1
@@ -2814,10 +2814,19 @@ class TestDyeTest(object):
         assert len(p2.instructions[0].informatics) == 1
         assert isinstance(p2.instructions[0].informatics[0], AttachCompounds)
 
+        p2.provision(
+            "rs123123123",
+            c1.well(2),
+            volumes="20:microliter",
+            informatics=[AttachCompounds([c1.well(2)], [compd1])],
+        )
+
+        assert len(p2.instructions[0].informatics) == 2
+
         p2.provision("rs123123123", c1.well(3), volumes="30:microliter")
 
-        assert len(p2.instructions[0].data["to"]) == 3
-        assert len(p2.instructions[0].informatics) == 1
+        assert len(p2.instructions[0].data["to"]) == 4
+        assert len(p2.instructions[0].informatics) == 2
 
         with pytest.raises(ValueError):
             _convert_provision_instructions(p1, "2", 3)


### PR DESCRIPTION
Add new optional attribute `informatics`
* `informatics` defaults to None for backward compatibility
* `informatics` is serialized only when it is not empty
* update `provision` to include `informatics` as an optional param