### PR TITLE
support: Update copyright year and active authors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,21 +8,21 @@ Here is a list of active contributors from Strateos:
 
 - Vanessa Biggers - `polarpine <https://github.com/polarpine>`_ - vanessa.biggers@strateos.com
 - Yang Choo - `yangchoo <https://github.com/yangchoo>`_ - yang.choo@strateos.com
-- Donald Dalton - `dbdalton2000 <https://github.com/dbdalton2000>`_ - donald.dalton@strateos.com
-- Varun Kanwar - `VarunKanwar <https://github.com/VarunKanwar>`_ - varun.kanwar@strateos.com
-- David Lyon - `dauglyon <https://github.com/dauglyon>`_ - david.lyon@strateos.com
 - Peter Lee - `pleaderlee <https://github.com/pleaderlee>`_ - peter.lee@strateos.com
 - Dylan Leidig - `dzleidig <https://github.com/dzleidig>`_ - dylan.leidig@strateos.com
 - Eriberto Lopez - `EribertoLopez <https://github.com/EribertoLopez>`_ - eriberto.lopez@strateos.com
-- Rhys Ormond - `rhysormond <https://github.com/rhysormond>`_ - rhys.ormond@strateos.com
 - Asuka Ota - `aota001 <https://github.com/aota001>`_ - asuka.ota@strateos.com
 - Joshua Nowak - `joshhacksthings <https://github.com/joshhacksthings>`_ - josh.nowak@strateos.com
 
 Especially active past contributors we're grateful to:
 
+- Donald Dalton - `dbdalton2000 <https://github.com/dbdalton2000>`_
+- David Lyon - `dauglyon <https://github.com/dauglyon>`_
 - Jeremy Apthorp - `nornagon <https://github.com/nornagon>`_
 - Jim Culver - `drjimmypants <https://github.com/drjimmypants>`_
 - Tali Herzka - `therzka <https://github.com/therzka>`_
+- Rhys Ormond - `rhysormond <https://github.com/rhysormond>`_
+- Varun Kanwar - `VarunKanwar <https://github.com/VarunKanwar>`_
 - Cornelia Scheitz - `cojofra <https://github.com/cojofra>`_
 
 `For a full list of Github contributors, please click here <https://github.com/autoprotocol/autoprotocol-python/contributors>`_

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
 License
 =======
 
-Copyright (c) 2020, Strateos Inc
+Copyright (c) 2021, Strateos Inc
 All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1,7 +1,7 @@
 """Builders
 Module containing builders, which help build inputs for Instruction parameters
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/constants.py
+++ b/autoprotocol/constants.py
@@ -1,7 +1,7 @@
 """
 Constants used in protocol design, specification, and checking
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1,7 +1,7 @@
 """
 Container, Well, WellGroup objects and associated functions
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -1,7 +1,7 @@
 """
 Container-type object and associated functions
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -1,7 +1,7 @@
 """
 Module containing the harness module which helps with Manifest interpretation
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/informatics.py
+++ b/autoprotocol/informatics.py
@@ -1,7 +1,7 @@
 """
 Contains all the Autoprotocol Informatics objects
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1,7 +1,7 @@
 """
 Contains all the Autoprotocol Instruction objects
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/liquid_handle/liquid_class.py
+++ b/autoprotocol/liquid_handle/liquid_class.py
@@ -3,7 +3,7 @@
 Base class for defining the portions of liquid handling behavior that are
 intrinsic to specific types of liquids.
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/liquid_handle/liquid_handle_method.py
+++ b/autoprotocol/liquid_handle/liquid_handle_method.py
@@ -2,7 +2,7 @@
 
 Base class for generating complex liquid handling behavior.
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/liquid_handle/mix.py
+++ b/autoprotocol/liquid_handle/mix.py
@@ -3,7 +3,7 @@
 Base LiquidHandleMethod used by Protocol.mix to generate a series of
 movements within individual wells.
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 """

--- a/autoprotocol/liquid_handle/tip_type.py
+++ b/autoprotocol/liquid_handle/tip_type.py
@@ -1,7 +1,7 @@
 """
 Generic tip type and device class mappings for LiquidHandleMethods
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 """

--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -1,6 +1,6 @@
 """Transfer LiquidHandleMethod
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1,7 +1,7 @@
 """
 Module containing the main `Protocol` object and associated functions
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/unit.py
+++ b/autoprotocol/unit.py
@@ -1,7 +1,7 @@
 """
 Module containing a Units library
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -1,7 +1,7 @@
 """
 Module containing utility functions
 
-    :copyright: 2020 by The Autoprotocol Development Team, see AUTHORS
+    :copyright: 2021 by The Autoprotocol Development Team, see AUTHORS
         for more details.
     :license: BSD, see LICENSE for more details
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`291` Update copyright and authors
 * :feature:`290` Add informatics attribute to Instruction
 
 * :release:`7.5.0 <2021-01-31>`


### PR DESCRIPTION
Update copyright year to 2021 and active authors list