### PR TITLE
feat: add informatics to LH

### DIFF
--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1849,16 +1849,19 @@ class LiquidHandle(Instruction):
         the liquid handling mode
     mode_params : dict, optional
         See Also :meth:`LiquidHandle.builders.instruction_mode_params`
+    informatics : list(Informatics), optional
+        List of Informatics describing the intended aliquot effects upon
+        completion of this instruction.
     """
 
     builders = LiquidHandleBuilders()
 
-    def __init__(self, locations, shape=None, mode=None, mode_params=None):
+    def __init__(self, locations, shape=None, mode=None, mode_params=None, informatics=None):
         data = {
             "locations": locations,
             "shape": shape,
             "mode": mode,
             "mode_params": mode_params,
         }
-
-        super(LiquidHandle, self).__init__(op="liquid_handle", data=data)
+        informatics = informatics
+        super(LiquidHandle, self).__init__(op="liquid_handle", data=data, informatics=informatics)

--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -1856,12 +1856,16 @@ class LiquidHandle(Instruction):
 
     builders = LiquidHandleBuilders()
 
-    def __init__(self, locations, shape=None, mode=None, mode_params=None, informatics=None):
+    def __init__(
+        self, locations, shape=None, mode=None, mode_params=None, informatics=None
+    ):
         data = {
             "locations": locations,
             "shape": shape,
             "mode": mode,
             "mode_params": mode_params,
         }
-        informatics = informatics
-        super(LiquidHandle, self).__init__(op="liquid_handle", data=data, informatics=informatics)
+
+        super(LiquidHandle, self).__init__(
+            op="liquid_handle", data=data, informatics=informatics
+        )

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -6848,12 +6848,7 @@ class Protocol(object):
                         "informatics": [
                             {
                                 "type: "attach_compounds",
-                                "data": [
-                                    {
-                                        "wells": "container/0",
-                                        "compounds": ["InChI=1S/CH4/h1H4"]
-                                    }
-                                ]
+                                "data": {"wells": "container/0", "compounds": ["InChI=1S/CH4/h1H4"]}
                             }
                         ]
                     },
@@ -6946,15 +6941,6 @@ class Protocol(object):
                     },
 
                     # Multiple Informatics for multiple wells in transfer from a source to many destination wells
-                p.transfer(
-                    resource.well(0).set_volume("40:microliter"),
-                    dest_wells,
-                    "5:microliter",
-                    informatics=[
-                        AttachCompounds([dest_wells[0], dest_wells[1]], [compd1]),
-                        AttachCompounds(dest_wells, [compd2])
-                    ]
-                )
                     {
                         "op": "liquid_handle"
                         "locations": [

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -6576,6 +6576,7 @@ class Protocol(object):
         one_tip=False,
         density=None,
         mode=None,
+        informatics=None,
     ):
         """Generates LiquidHandle instructions between wells
 
@@ -6611,7 +6612,9 @@ class Protocol(object):
             Density of the liquid to be aspirated/dispensed
         mode : str, optional
             The liquid handling mode
-
+        informatics : list(Informatics), optional
+            List of Informatics describing the intended aliquot effects upon
+            completion of this instruction.
         Returns
         -------
         list(LiquidHandle)
@@ -6866,6 +6869,7 @@ class Protocol(object):
                                     tip_type=met.tip_type
                                 )
                             ),
+                            informatics=informatics
                         )
                     )
                 remaining_vol -= transfer_vol

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -6791,9 +6791,13 @@ class Protocol(object):
                                     compd = [compd]
                                 informatics_list.append(AttachCompounds(well, compd))
                     else:
-                        raise ValueError(f"Informatics wells: {wells} do not match wells used in Instruction.")
+                        raise ValueError(
+                            f"Informatics wells: {wells} do not match wells used in Instruction."
+                        )
                 else:
-                    raise TypeError(f"Informatics:{informatics} is not available in this protocol.")
+                    raise TypeError(
+                        f"Informatics:{informatics} is not available in this protocol."
+                    )
             else:
                 wells_compounds_dict = {}
                 for info in informatics:
@@ -6809,12 +6813,15 @@ class Protocol(object):
                                     f"intent is ambiguous."
                                 )
                     else:
-                        raise TypeError(f"Informatics:{informatics} is not available in this protocol.")
+                        raise TypeError(
+                            f"Informatics:{informatics} is not available in this protocol."
+                        )
                 if len(wells_compounds_dict.keys()) == dest_count:
                     informatics_list = []
                     # sort informatics_list by the destination order
                     wells_compounds_dict = sorted(
-                        wells_compounds_dict.items(), key=lambda pair: destination.wells.index(pair[0])
+                        wells_compounds_dict.items(),
+                        key=lambda pair: destination.wells.index(pair[0]),
                     )
                     for k, v in wells_compounds_dict:
                         if not isinstance(v, list):
@@ -6888,7 +6895,7 @@ class Protocol(object):
             source_liquid,
             destination_liquid,
             method,
-            informatics_list
+            informatics_list,
         )
         correct_parameter_counts = all(len(_) == count for _ in countable_parameters)
         if not correct_parameter_counts:
@@ -6959,7 +6966,7 @@ class Protocol(object):
                                     tip_type=met.tip_type
                                 )
                             ),
-                            informatics=informatics
+                            informatics=informatics,
                         )
                     )
                 remaining_vol -= transfer_vol

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`292` Add informatics param to LiquidHandle
 * :support:`291` Update copyright and authors
 * :feature:`290` Add informatics attribute to Instruction
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`292` Add informatics param to LiquidHandle
+* :feature:`292` Add informatics param to p.transfer
 * :support:`291` Update copyright and authors
 * :feature:`290` Add informatics attribute to Instruction
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -3411,17 +3411,19 @@ class TestTransferVolume(object):
             informatics=[
                 AttachCompounds([test_wells[0], test_wells[1]], [compd1]),
                 AttachCompounds(
-                    [test_wells[2], test_wells[3]],
+                    test_wells,
                     [compd2],
                 ),
             ],
         )
         new_instructions = self.p.instructions[-4:]
         assert len(new_instructions[0].informatics) == 1
-        assert new_instructions[0].informatics[0].compounds[0] == compd1
-        assert new_instructions[1].informatics[0].compounds[0] == compd1
-        assert new_instructions[2].informatics[0].compounds[0] == compd2
-        assert new_instructions[3].informatics[0].compounds[0] == compd2
+        assert len(new_instructions[0].informatics[0].compounds) == 2
+        assert set(new_instructions[0].informatics[0].compounds) == {compd1, compd2}
+        assert len(new_instructions[1].informatics[0].compounds) == 2
+        assert len(new_instructions[2].informatics[0].compounds) == 1
+        assert new_instructions[2].informatics[0].compounds == [compd2]
+        assert new_instructions[3].informatics[0].compounds == [compd2]
 
         # Test case for Informatics wells order not aligned with destination
         self.p.transfer(

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -3403,7 +3403,7 @@ class TestTransferVolume(object):
             wells.append(instr.informatics[0].wells)
         assert WellGroup(wells) == test_wells
 
-        # Test case for multiple destinations with multiple Informatics in order
+        # Test with multiple AttachCompounds with different compounds provided for destination wells
         self.p.transfer(
             resource.well(0).set_volume("40:microliter"),
             test_wells,
@@ -3425,7 +3425,7 @@ class TestTransferVolume(object):
         assert new_instructions[2].informatics[0].compounds == [compd2]
         assert new_instructions[3].informatics[0].compounds == [compd2]
 
-        # Test case for Informatics wells order not aligned with destination
+        # Test case for Informatics when AttachComounds 'wells' order is not aligned with destination wells order
         self.p.transfer(
             resource.well(0).set_volume("40:microliter"),
             test_wells,
@@ -3488,6 +3488,7 @@ class TestTransferVolume(object):
         assert len(self.p.instructions[-1].informatics[0].compounds) == 2
         assert set(self.p.instructions[-1].informatics[0].compounds) == {compd1, compd2}
 
+        # Informatics must be provided for all destination wells
         with pytest.raises(ValueError):
             self.p.transfer(
                 [
@@ -3498,6 +3499,7 @@ class TestTransferVolume(object):
                 "10:microliter",
                 informatics=[AttachCompounds(test_wells[2], [compd1])],
             )
+        # Informatics well must be operated on in the Instruction
         with pytest.raises(ValueError):
             self.p.transfer(
                 resource.well(0).set_volume("40:microliter"),
@@ -3505,6 +3507,7 @@ class TestTransferVolume(object):
                 "10:microliter",
                 informatics=[AttachCompounds(test_wells[2], [compd1])],
             )
+        # Informatics must be a valid type
         with pytest.raises(TypeError):
             self.p.transfer(
                 resource.well(0).set_volume("40:microliter"),
@@ -3512,12 +3515,21 @@ class TestTransferVolume(object):
                 "10:microliter",
                 informatics=["foo"],
             )
+        # All Informatics wells must be part of the Instruction wells
         with pytest.raises(ValueError):
             self.p.transfer(
                 resource.well(0).set_volume("40:microliter"),
                 test_wells[0],
                 "10:microliter",
                 informatics=[AttachCompounds([test_wells[0], test_wells[1]], [compd1])],
+            )
+        # cannot provide informatics for the source well
+        with pytest.raises(ValueError):
+            self.p.transfer(
+                resource.well(0).set_volume("40:microliter"),
+                test_wells[0],
+                "10:microliter",
+                informatics=[AttachCompounds(resource.well(0), [compd1])],
             )
 
     def test_can_append_properties(self):

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -77,6 +77,7 @@ class TestProtocolBasic(object):
 
         assert len(protocol.instructions) == 2
         assert protocol.instructions[0].op == "liquid_handle"
+        assert protocol.instructions[0].informatics == []
 
         protocol.incubate(bacteria, "warm_37", "30:minute")
 
@@ -84,6 +85,18 @@ class TestProtocolBasic(object):
         assert protocol.instructions[2].op == "cover"
         assert protocol.instructions[3].op == "incubate"
         assert protocol.instructions[3].duration == "30:minute"
+
+        protocol.transfer(
+            resource.well(0).set_volume("40:microliter"),
+            bacteria.well(1),
+            "5:microliter",
+            informatics=[AttachCompounds(bacteria.well(1), [Compound("InChI=1S/CH4/h1H4")])]
+        )
+        assert protocol.instructions[-1].op == "liquid_handle"
+        assert len(protocol.instructions[-1].informatics) == 1
+        assert isinstance(protocol.instructions[-1].informatics[0], AttachCompounds)
+        assert protocol.instructions[-1].informatics[0].wells == bacteria.well(1)
+        assert protocol.instructions[-1].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
 
 
 class TestProtocolAppendReturn(object):

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -3375,20 +3375,25 @@ class TestTransferVolume(object):
             resource.well(0).set_volume("40:microliter"),
             test_wells[0],
             "5:microliter",
-            informatics=[AttachCompounds(test_wells[0], [Compound("InChI=1S/CH4/h1H4")])]
+            informatics=[
+                AttachCompounds(test_wells[0], [Compound("InChI=1S/CH4/h1H4")])
+            ],
         )
         assert self.p.instructions[-1].op == "liquid_handle"
         assert len(self.p.instructions[-1].informatics) == 1
         assert isinstance(self.p.instructions[-1].informatics[0], AttachCompounds)
         assert self.p.instructions[-1].informatics[0].wells == test_wells[0]
-        assert self.p.instructions[-1].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
+        assert (
+            self.p.instructions[-1].informatics[0].compounds[0].InChI
+            == "InChI=1S/CH4/h1H4"
+        )
 
         # Test case for multiple destination wells with single Informatics
         self.p.transfer(
             resource.well(0).set_volume("40:microliter"),
             test_wells,
             "5:microliter",
-            informatics=[AttachCompounds(test_wells, [Compound("InChI=1S/CH4/h1H4")])]
+            informatics=[AttachCompounds(test_wells, [Compound("InChI=1S/CH4/h1H4")])],
         )
         assert self.p.instructions[-1].op == "liquid_handle"
         new_instructions = self.p.instructions[-4:]
@@ -3406,40 +3411,64 @@ class TestTransferVolume(object):
             resource.well(0).set_volume("40:microliter"),
             test_wells,
             "5:microliter",
-            informatics=[AttachCompounds(
-                [test_wells[0], test_wells[1]],
-                [Compound("InChI=1S/CH4/h1H4")]
-            ), AttachCompounds(
-                [test_wells[2], test_wells[3]],
-                [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")]
-            )]
+            informatics=[
+                AttachCompounds(
+                    [test_wells[0], test_wells[1]], [Compound("InChI=1S/CH4/h1H4")]
+                ),
+                AttachCompounds(
+                    [test_wells[2], test_wells[3]],
+                    [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")],
+                ),
+            ],
         )
         new_instructions = self.p.instructions[-4:]
         assert len(new_instructions[0].informatics) == 1
-        assert new_instructions[0].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
-        assert new_instructions[1].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
-        assert new_instructions[2].informatics[0].compounds[0].InChI == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
-        assert new_instructions[3].informatics[0].compounds[0].InChI == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        assert (
+            new_instructions[0].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
+        )
+        assert (
+            new_instructions[1].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
+        )
+        assert (
+            new_instructions[2].informatics[0].compounds[0].InChI
+            == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        )
+        assert (
+            new_instructions[3].informatics[0].compounds[0].InChI
+            == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        )
 
         # Test case for Informatics wells order not aligned with destination
         self.p.transfer(
             resource.well(0).set_volume("40:microliter"),
             test_wells,
             "5:microliter",
-            informatics=[AttachCompounds(
-                [test_wells[0], test_wells[2]],
-                [Compound("InChI=1S/CH4/h1H4")]
-            ), AttachCompounds(
-                [test_wells[1], test_wells[3]],
-                [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")]
-            )]
+            informatics=[
+                AttachCompounds(
+                    [test_wells[0], test_wells[2]], [Compound("InChI=1S/CH4/h1H4")]
+                ),
+                AttachCompounds(
+                    [test_wells[1], test_wells[3]],
+                    [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")],
+                ),
+            ],
         )
         new_instructions = self.p.instructions[-4:]
         assert len(new_instructions[0].informatics) == 1
-        assert new_instructions[0].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
-        assert new_instructions[1].informatics[0].compounds[0].InChI == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
-        assert new_instructions[2].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
-        assert new_instructions[3].informatics[0].compounds[0].InChI == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        assert (
+            new_instructions[0].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
+        )
+        assert (
+            new_instructions[1].informatics[0].compounds[0].InChI
+            == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        )
+        assert (
+            new_instructions[2].informatics[0].compounds[0].InChI == "InChI=1S/CH4/h1H4"
+        )
+        assert (
+            new_instructions[3].informatics[0].compounds[0].InChI
+            == "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+        )
         wells = []
         for instr in new_instructions:
             wells.append(instr.informatics[0].wells)
@@ -3452,21 +3481,21 @@ class TestTransferVolume(object):
                 "10:microliter",
                 informatics=[
                     AttachCompounds(test_wells[2], [Compound("InChI=1S/CH4/h1H4")])
-                ]
+                ],
             )
         with pytest.raises(TypeError):
             self.p.transfer(
                 resource.well(0).set_volume("40:microliter"),
                 test_wells[0],
                 "10:microliter",
-                informatics=["foo"]
+                informatics=["foo"],
             )
         with pytest.raises(TypeError):
             self.p.transfer(
                 resource.well(0).set_volume("40:microliter"),
                 test_wells[0],
                 "10:microliter",
-                informatics=["foo"]
+                informatics=["foo"],
             )
         with pytest.raises(ValueError):
             self.p.transfer(
@@ -3475,8 +3504,10 @@ class TestTransferVolume(object):
                 "10:microliter",
                 informatics=[
                     AttachCompounds(test_wells[0], [Compound("InChI=1S/CH4/h1H4")]),
-                    AttachCompounds(test_wells[0], [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")])
-                ]
+                    AttachCompounds(
+                        test_wells[0], [Compound("InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")]
+                    ),
+                ],
             )
         with pytest.raises(ValueError):
             self.p.transfer(
@@ -3484,10 +3515,11 @@ class TestTransferVolume(object):
                 test_wells[0],
                 "10:microliter",
                 informatics=[
-                    AttachCompounds([test_wells[0], test_wells[1]], [Compound("InChI=1S/CH4/h1H4")])
-                ]
+                    AttachCompounds(
+                        [test_wells[0], test_wells[1]], [Compound("InChI=1S/CH4/h1H4")]
+                    )
+                ],
             )
-
 
     def test_can_append_properties(self):
         """Expected behavior when propagating properties to wells with prior properties."""


### PR DESCRIPTION
@yangchoo 
Informatics need to be implemented in LH as well.
However, there's one issue... 
In LH, transfer form one source to multiple destinations (e.g. source=resourceA, dests = [aliquot1, aliquot2 aliquot3]) would instantiate 3 Instruction: Instruction("liquid_handle" for resourceA to aliquot1), Instruction("liquid_handle" for resourceA to aliquot2), Instruction("liquid_handle" for resourceA to aliquot3). This is a problem with how we are handling informatics, since informatics is provided at Protocol level (p.transfer), but the validations are happening at each Instruction... which means if Informatics has dest wells: [aliquot1, aliquot2, aliquot3], it fails (on informatics wells is part of Instruction wells) since at Instruction, there is one destination well at a time.
We could move validation back to the Protocol, or if we think LH is an edge case, we can have custom check just for this... thoughts???
