### PR TITLE
Add container attribute

### DIFF
--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -20,6 +20,7 @@ class ContainerType(
         "ContainerType",
         [
             "name",
+            "is_reservoir",
             "is_tube",
             "well_count",
             "well_depth_mm",
@@ -111,6 +112,7 @@ class ContainerType(
         vendor=None,
         cat_no=None,
         prioritize_seal_or_cover="seal",
+        is_reservoir=False
     ):
         true_max_vol_ul = true_max_vol_ul or well_volume_ul
         assert true_max_vol_ul >= well_volume_ul, (
@@ -120,6 +122,7 @@ class ContainerType(
         return super(ContainerType, cls).__new__(
             cls,
             name,
+            is_reservoir,
             is_tube,
             well_count,
             well_depth_mm,
@@ -409,7 +412,6 @@ FLAT384 = ContainerType(
     vendor="Corning",
     cat_no="3706",
 )
-
 
 #:
 PCR384 = ContainerType(
@@ -1072,6 +1074,10 @@ ROUND384CLEAR = ContainerType(
 )
 
 #:
+# I set is-reservoir in container object to true for this container below where the error occurred in Xi's run. 
+# For all other containers the is_reservoir param is defaulted to false via the class definition. 
+# If there are cases where this container does not act as a reservoir it may be better to, change the default to true from
+# the specific client protocol code instead. This will ensure that the change will not affect gingko etc.
 RESSW384LP = ContainerType(
     name="384-well singlewell lowprofile reservoir",
     well_count=1,
@@ -1079,6 +1085,7 @@ RESSW384LP = ContainerType(
     well_volume_ul=Unit(35, "milliliter"),
     well_coating=None,
     sterile=False,
+    is_reservoir=True,
     is_tube=False,
     cover_types=["universal"],
     seal_types=None,

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -1074,10 +1074,6 @@ ROUND384CLEAR = ContainerType(
 )
 
 #:
-# I set is-reservoir in container object to true for this container below where the error occurred in Xi's run. 
-# For all other containers the is_reservoir param is defaulted to false via the class definition. 
-# If there are cases where this container does not act as a reservoir it may be better to, change the default to true from
-# the specific client protocol code instead. This will ensure that the change will not affect gingko etc.
 RESSW384LP = ContainerType(
     name="384-well singlewell lowprofile reservoir",
     well_count=1,
@@ -1085,7 +1081,6 @@ RESSW384LP = ContainerType(
     well_volume_ul=Unit(35, "milliliter"),
     well_coating=None,
     sterile=False,
-    is_reservoir=True,
     is_tube=False,
     cover_types=["universal"],
     seal_types=None,

--- a/autoprotocol/container_type.py
+++ b/autoprotocol/container_type.py
@@ -49,6 +49,8 @@ class ContainerType(
     ----------
     name : str
       Full name describing a ContainerType.
+    is_reservoir: bool
+      Indicates whether a ContainerType will act as a reservoir default false.
     is_tube : bool
       Indicates whether a ContainerType is a tube (container with one well).
     well_count : int

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -180,7 +180,8 @@ def _check_container_type_with_shape(container_type, shape):
                 f"1 or divisible by 2, but {shape} was specified."
             )
 
-    if shape["format"] == "SBS384" and container_wells < 384:
+# access reservoir attribute from predefined container type to determine if stampable
+    if shape["format"] == "SBS384" and container_wells < 384 and container_type.is_reservoir == False:
         raise ValueError(
             f"SBS384 transfers can only be executed in 384 well plates, but "
             f"container_type: {container_type} has {container_wells} wells."

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -179,7 +179,7 @@ def _check_container_type_with_shape(container_type, shape):
                 f"containers must have row and column counts either equal to "
                 f"1 or divisible by 2, but {shape} was specified."
             )
-
+ 
 # access reservoir attribute from predefined container type to determine if stampable
     if shape["format"] == "SBS384" and container_wells < 384 and container_type.is_reservoir == False:
         raise ValueError(

--- a/test/container_type_test.py
+++ b/test/container_type_test.py
@@ -95,6 +95,8 @@ class TestContainerTypeAttributes(object):
         assert dummy_type.vendor is None
         assert dummy_type.cat_no is None
         assert dummy_type.true_max_vol_ul == dummy_type.well_volume_ul
+        assert dummy_type.is_reservoir == False
+        
 
     def test_echo_attributes(self, dummy_echo):
         assert dummy_echo.container_type.vendor == "Labcyte"
@@ -103,3 +105,8 @@ class TestContainerTypeAttributes(object):
             dummy_echo.container_type.true_max_vol_ul
             > dummy_echo.container_type.well_volume_ul
         )
+
+# from autoprotocol.container_type import _CONTAINER_TYPES
+# a = TestContainerTypeAttributes()
+# a.test_default_attributes(_CONTAINER_TYPES["res-sw384-lp"])
+

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from autoprotocol.unit import Unit
 from autoprotocol.util import parse_unit
-
+from autoprotocol.container_type import _CONTAINER_TYPES
 
 class TestParseUnit(object):
     def test_casting_to_unit(self):
@@ -25,3 +25,16 @@ class TestParseUnit(object):
 
         with pytest.raises(TypeError):
             parse_unit("1:ul", ["second", "kg"])
+
+    def test_reservoir(self):
+        container_type_reservoir = _CONTAINER_TYPES["res-sw384-lp"]
+        assert container_type_reservoir.is_reservoir == True
+        # print(container_type_reservoir.is_reservoir)
+
+        container_type_non_reservoir = _CONTAINER_TYPES["384-echo-ldv"]
+        assert container_type_non_reservoir.is_reservoir == False        
+        # print(container_type_non_reservoir.is_reservoir)
+
+# a = TestParseUnit()
+
+# a.test_reservoir()

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from autoprotocol.unit import Unit
 from autoprotocol.util import parse_unit
-from autoprotocol.container_type import _CONTAINER_TYPES
+# from autoprotocol.container_type import _CONTAINER_TYPES
 
 class TestParseUnit(object):
     def test_casting_to_unit(self):
@@ -26,15 +26,7 @@ class TestParseUnit(object):
         with pytest.raises(TypeError):
             parse_unit("1:ul", ["second", "kg"])
 
-    def test_reservoir(self):
-        container_type_reservoir = _CONTAINER_TYPES["res-sw384-lp"]
-        assert container_type_reservoir.is_reservoir == True
-        # print(container_type_reservoir.is_reservoir)
-
-        container_type_non_reservoir = _CONTAINER_TYPES["384-echo-ldv"]
-        assert container_type_non_reservoir.is_reservoir == False        
-        # print(container_type_non_reservoir.is_reservoir)
-
-# a = TestParseUnit()
-
-# a.test_reservoir()
+    # def test_reservoir(self):
+    #     container_type_reservoir = _CONTAINER_TYPES["res-sw384-lp"]
+    #     assert container_type_reservoir.is_reservoir == False
+    #     # print(container_type_reservoir.is_reservoir)

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from autoprotocol.unit import Unit
 from autoprotocol.util import parse_unit
-# from autoprotocol.container_type import _CONTAINER_TYPES
 
 class TestParseUnit(object):
     def test_casting_to_unit(self):
@@ -25,8 +24,3 @@ class TestParseUnit(object):
 
         with pytest.raises(TypeError):
             parse_unit("1:ul", ["second", "kg"])
-
-    # def test_reservoir(self):
-    #     container_type_reservoir = _CONTAINER_TYPES["res-sw384-lp"]
-    #     assert container_type_reservoir.is_reservoir == False
-    #     # print(container_type_reservoir.is_reservoir)


### PR DESCRIPTION
Added container attribute: is_reservoir
This boolean is evaluated in **utils.py** to bypass 384 well only stamping.

The intention is for stdev to overwrite this default property from false to true in internal protocols for clients when it makes sense. 

In the other branch called: **define-reservoir-from-attributes**, I define a reservoir from the container attributes, which is less robust and would likely cause errors for others consuming appy. Did it just for comparison.
