### PR TITLE
fix: equivalency change

### DIFF
--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -119,7 +119,7 @@ def param_default(type_desc):
 
         return {"value": default, "inputs": default_inputs}
     elif type_desc["type"] == "csv-table":
-        return [{}, {}]
+        return [{}, [{}]]
     else:
         return None
 


### PR DESCRIPTION
changing string comparison from the `in` operator to an `==` when comparing if the input type `type` of a `compound` input type.