### PR TITLE
verion bump and changelog update

### DIFF
--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "7.9.3"
+__version__ = "7.9.4"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release:`7.9.4 <2021-09-21>`
+* :feature:`308` Update `liquid_handle_dispense` instruction to allow for multiple intake hoses in source
+
 * :release:`7.9.3 <2021-09-13>`
 * :feature:`306` Add new containers: `384-ubottom-black-clear-tc` and `384-flat-black-clear-tc`
 * :feature:`305` Add `cold_196` incubation location


### PR DESCRIPTION
preparing for release-v7.9.4
* :release:`7.9.4 <2021-09-21>`
* :feature:`308` Update `liquid_handle_dispense` instruction to allow for multiple intake hoses in source