### PR TITLE
Fix container mass extraction

### DIFF
--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -460,8 +460,8 @@ class ProtocolInfo(object):
                     c.well(idx).set_volume(aq["volume"])
                     if "name" in aq:
                         c.well(idx).set_name(aq["name"])
-                    if "mass_mg" in aq:
-                        c.well(idx).set_mass(aq["mass_mg"])
+                    if "mass" in aq:
+                        c.well(idx).set_mass(aq["mass"])
                     if "properties" in aq:
                         c.well(idx).set_properties(aq.get("properties"))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release:`unreleased <>`
+* :feature:`316` Add new container: `96-pcr-fs-clear`
+
 * :release:`7.9.5 <2021-09-30>`
 * :feature:`312` Add new container: `96-pcr-fs-clear`
 * :feature:`309` Change container short name `384-flat-black-clear-tc` to `384-flatbottom-black-clear-tc`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :release:`unreleased <>`
+* :release:`7.9.6 <2021-10-18>`
 * :feature:`316` Add new container: `96-pcr-fs-clear`
 
 * :release:`7.9.5 <2021-09-30>`

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -532,7 +532,7 @@ class TestManifest(object):
                         "type": "384-echo",
                         "discard": True,
                         "aliquots": {
-                            "0": {"volume": "10:microliter", "mass_mg": "100:milligram"}
+                            "0": {"volume": "10:microliter", "mass": "100:milligram"}
                         },
                     }
                 },


### PR DESCRIPTION
Extracting mass from containers was using the key `mass_mg` when we actually expect `mass` attribute (no underscore unit). This PR fixes that. Updated test.