### PR TITLE
build: Bump pre-commit lib versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.0.1
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.9b0
     hooks:
     -   id: black
         language_version: python3.6
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+    rev: 5.9.3
     hooks:
       - id: isort
 -   repo: https://github.com/pycqa/pylint

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :support:`318` Update all pre-commit hooks except pylint to latest versions
+
 * :release:`7.10.0 <2021-10-25>`
 * :support:`321` Support `mass=None` assignment
 * :feature:`319` Support Python 3.10


### PR DESCRIPTION
Bumps all pre-commit libraries except pylint to their latest versions.
There are no breaking changes introduced here.

