### PR TITLE
test: Bump pytest and pytest-cov versions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :support:`320` Bump pytest and pytest-cov versions for python 3.10 support
+* :support:`320` Bump pytest, pytest-cov and coverage versions for python 3.10 support
 
 * :release:`7.9.6 <2021-10-18>`
 * :feature:`316` Add new container: `96-pcr-fs-clear`

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class PyTest(TestCommand):
 
 # Test and Documentation dependencies
 test_deps = [
-    "coverage>=4.5, <5",
+    "coverage>=6, <7",
     "pre-commit>=2.4, <3",
     "pylint==2.5.2",  # should be consistent with .pre-commit-config.yaml
     "pytest>=6.2.5, <7",


### PR DESCRIPTION
Bump pytest and pytest-cov versions which are required for Python 3.10
support.