### PR TITLE
Extract list of compounds, and associated metadata, when constructing aliquots with said data

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -409,8 +409,10 @@ class Well(EntityPropertiesMixin):
                 raise RuntimeError(
                     "Compound information must include `id`, `molecularWeight`, and `smiles` keys."
                 )
-            # Transform string molecularWeight -> Unit molecularWeight
-            compound["molecularWeight"] = Unit(compound["molecularWeight"], "g/mol")
+            # Transform {"molecularWeight": float} -> {"molecular_weight": Unit}
+            compound["molecular_weight"] = Unit(
+                compound.pop("molecularWeight"), "g/mol"
+            )
 
         self.compounds = compounds
         return self

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -302,6 +302,7 @@ class Well(EntityPropertiesMixin):
         self.volume = None
         self.mass = None
         self.name = None
+        self.compounds = None
         self.properties = properties if isinstance(properties, dict) else dict()
         self.ctx_properties = self.fromDict(ctx_properties)
 
@@ -373,6 +374,45 @@ class Well(EntityPropertiesMixin):
                 f"volume {max_vol}."
             )
         self.volume = v
+        return self
+
+    def set_compounds(self, compounds):
+        """
+        Sets the list of associated compounds, and their metadata, to an aliquot.
+
+        Parameters
+        ----------
+        compounds : list
+            List of compounds associated to a well.
+
+        Returns
+        -------
+        Well
+            Well with associated compounds
+
+        Raises
+        ------
+        TypeError
+            Incorrect input-type given
+        RuntimeError
+            Compound information does not contain required keys
+        """
+        expected_keys = {"id", "molecularWeight", "smiles"}
+        if not isinstance(compounds, list):
+            raise TypeError(
+                f"Compound list {compounds} is of type {type(compounds)}, it should be a 'list'."
+            )
+
+        for compound in compounds:
+            # Check all expected keys aer present
+            if set(compound.keys()) != expected_keys:
+                raise RuntimeError(
+                    "Compound information must include `id`, `molecularWeight`, and `smiles` keys."
+                )
+            # Transform string molecularWeight -> Unit molecularWeight
+            compound["molecularWeight"] = Unit(compound["molecularWeight"], "g/mol")
+
+        self.compounds = compounds
         return self
 
     def add_volume(self, vol: Unit):

--- a/autoprotocol/harness.py
+++ b/autoprotocol/harness.py
@@ -470,6 +470,8 @@ class ProtocolInfo(object):
                         c.well(idx).set_ctx_properties(
                             aq.get("contextual_custom_properties")
                         )
+                    if "compounds" in aq:
+                        c.well(idx).set_compounds(aq.get("compounds"))
 
         out_params = {}
         for k in self.input_types:

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -786,6 +786,6 @@ class TestManifest(object):
             },
         )
         expected_compounds_list = [
-            {"id": "123", "molecularWeight": Unit(100, "g/mol"), "smiles": "CCCC"}
+            {"id": "123", "molecular_weight": Unit(100, "g/mol"), "smiles": "CCCC"}
         ]
         assert parsed["cont"].well(0).compounds == expected_compounds_list

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -753,3 +753,39 @@ class TestManifest(object):
             )
 
         assert "foo is not an acceptable Compound format." in str(e.value)
+
+    def test_compound_linkage_list(self):
+        protocol_info = ProtocolInfo(
+            {
+                "name": "Test Container With Compounds",
+                "inputs": {"cont": {"type": "container"}},
+            }
+        )
+        parsed = protocol_info.parse(
+            self.protocol,
+            {
+                "refs": {
+                    "echo_plate": {
+                        "type": "384-echo",
+                        "discard": True,
+                        "aliquots": {
+                            "0": {
+                                "volume": "10:microliter",
+                                "compounds": [
+                                    {
+                                        "id": "123",
+                                        "molecularWeight": 100,
+                                        "smiles": "CCCC",
+                                    }
+                                ],
+                            }
+                        },
+                    }
+                },
+                "parameters": {"cont": "echo_plate"},
+            },
+        )
+        expected_compounds_list = [
+            {"id": "123", "molecularWeight": Unit(100, "g/mol"), "smiles": "CCCC"}
+        ]
+        assert parsed["cont"].well(0).compounds == expected_compounds_list


### PR DESCRIPTION
When we receive a JSON payload with the expected schema for compound declaration, we should associate these linked compounds to the `Well` they reside in.

This is the kind of structure we're expecting to receive, and we should only allow compounds with `id`, `molecularWeight`, and `smiles` keys to be associated, as we may need some of these keys in downstream applications. Any other keys to be considered should be included in a new ASC (autoprotocol standard change)
```
"compounds": [
    {.
        "id": "123",
        "molecularWeight": 100,
        "smiles": "CCCC",
    }
]
```