### PR TITLE
Update `set_compounds` on Well to allow compounds without all properties

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -394,8 +394,6 @@ class Well(EntityPropertiesMixin):
         ------
         TypeError
             Incorrect input-type given
-        RuntimeError
-            Compound information does not contain required keys
         """
         expected_keys = {
             "id",
@@ -410,19 +408,20 @@ class Well(EntityPropertiesMixin):
             )
 
         for compound in compounds:
-            # Check all expected keys aer present
-            if set(compound.keys()) != expected_keys:
-                raise RuntimeError(
-                    "Compound information must include `id`, `molecularWeight`, `concentration`, `solubilityFlag` and `smiles` keys."
-                )
-            # Transform {"molecularWeight": float} -> {"molecular_weight": Unit}
-            compound["molecular_weight"] = Unit(
-                compound.pop("molecularWeight"), "g/mol"
-            )
-            compound["solubility_flag"] = compound.pop("solubilityFlag")
-            compound["concentration"] = Unit(
-                compound.pop("concentration"), "millimol/liter"
-            )
+            if isinstance(compound, dict):
+                if compound.get("molecular_weight"):
+                    # transform {"molecularWeight": float} -> {"molecular_weight": Unit}
+                    compound["molecular_weight"] = Unit(
+                        compound.pop("molecularWeight"), "g/mol"
+                    )
+                if compound.get("solubility_flag"):
+                    compound["solubility_flag"] = compound.pop("solubilityFlag")
+                if compound["concentration"]:
+                    compound["concentration"] = Unit(
+                        compound.pop("concentration"), "millimol/liter"
+                    )
+            else:
+                pass
 
         self.compounds = compounds
         return self

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -429,7 +429,6 @@ class Well(EntityPropertiesMixin):
                     else:
                         # set unspecified keys using preferred param string
                         compound[expected_params[k]] = None
-
             else:
                 pass
 

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -420,6 +420,14 @@ class Well(EntityPropertiesMixin):
                     compound["concentration"] = Unit(
                         compound.pop("concentration"), "millimol/liter"
                     )
+                if compound.get("smiles"):
+                    # TODO: validation on smiles
+                    pass
+                else:
+                    compound["smiles"] = None
+                if not compound.get("id"):
+                    compound["id"] = None
+
             else:
                 pass
 

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -395,12 +395,13 @@ class Well(EntityPropertiesMixin):
         TypeError
             Incorrect input-type given
         """
-        expected_keys = {
-            "id",
-            "molecularWeight",
-            "smiles",
-            "concentration",
-            "solubilityFlag",
+        # expected parameters and label transformations
+        expected_params = {
+            "id": "id",
+            "molecularWeight": "molecular_weight",
+            "smiles": "smiles",
+            "concentration": "concentration",
+            "solubilityFlag": "solubility_flag",
         }
         if not isinstance(compounds, list):
             raise TypeError(
@@ -409,24 +410,25 @@ class Well(EntityPropertiesMixin):
 
         for compound in compounds:
             if isinstance(compound, dict):
-                if compound.get("molecular_weight"):
-                    # transform {"molecularWeight": float} -> {"molecular_weight": Unit}
-                    compound["molecular_weight"] = Unit(
-                        compound.pop("molecularWeight"), "g/mol"
-                    )
-                if compound.get("solubility_flag"):
-                    compound["solubility_flag"] = compound.pop("solubilityFlag")
-                if compound["concentration"]:
-                    compound["concentration"] = Unit(
-                        compound.pop("concentration"), "millimol/liter"
-                    )
-                if compound.get("smiles"):
-                    # TODO: validation on smiles
-                    pass
-                else:
-                    compound["smiles"] = None
-                if not compound.get("id"):
-                    compound["id"] = None
+                for k in expected_params:
+                    if k in compound:
+                        # transform {"molecularWeight": float} -> {"molecular_weight": Unit}
+                        if k == "molecularWeight":
+                            compound[expected_params[k]] = Unit(
+                                compound.pop("molecularWeight"), "g/mol"
+                            )
+                        elif k == "solubilityFlag":
+                            compound[expected_params[k]] = compound.pop("solubilityFlag")
+                        elif k == "concentration":
+                            compound[expected_params[k]] = Unit(compound.pop("concentration"), "millimol/liter")
+                        elif k == "smiles":
+                            # TODO: validation on smiles
+                            pass
+                        else:
+                            pass
+                    else:
+                        # set unspecified keys using preferred param string
+                        compound[expected_params[k]] = None
 
             else:
                 pass

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -418,9 +418,13 @@ class Well(EntityPropertiesMixin):
                                 compound.pop("molecularWeight"), "g/mol"
                             )
                         elif k == "solubilityFlag":
-                            compound[expected_params[k]] = compound.pop("solubilityFlag")
+                            compound[expected_params[k]] = compound.pop(
+                                "solubilityFlag"
+                            )
                         elif k == "concentration":
-                            compound[expected_params[k]] = Unit(compound.pop("concentration"), "millimol/liter")
+                            compound[expected_params[k]] = Unit(
+                                compound.pop("concentration"), "millimol/liter"
+                            )
                         elif k == "smiles":
                             # TODO: validation on smiles
                             pass

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`-` Update requirements for tracking concentration on compounds
+
 * :release:`7.13.1 <2021-12-02>`
 * :feature:`334` Addition of `concentration` and `solubility_flag` keys to compound metadata
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`-` Update requirements for tracking concentration on compounds
+* :feature:`-` Update requirements for tracking concentration on compounds, set defaults
 
 * :release:`7.13.1 <2021-12-02>`
 * :feature:`334` Addition of `concentration` and `solubility_flag` keys to compound metadata

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -780,6 +780,16 @@ class TestManifest(object):
                                         "concentration": 10,
                                     }
                                 ],
+                            },
+                            "1": {
+                                "volume": "10:microliter",
+                                "compounds": [
+                                    {
+                                        "id": "123",
+                                        "molecularWeight": 100,
+                                        "concentration": 10,
+                                    }
+                                ],
                             }
                         },
                     }
@@ -796,4 +806,15 @@ class TestManifest(object):
                 "concentration": Unit(10, "millimol/liter"),
             }
         ]
+        expected_compounds_list_default = [
+            {
+                "id": "123",
+                "molecular_weight": Unit(100, "g/mol"),
+                "smiles": None,
+                "solubility_flag": None,
+                "concentration": Unit(10, "millimol/liter"),
+            }
+        ]
         assert parsed["cont"].well(0).compounds == expected_compounds_list
+        # check non-specified values set to None
+        assert parsed["cont"].well(1).compounds == expected_compounds_list_default

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -790,7 +790,7 @@ class TestManifest(object):
                                         "concentration": 10,
                                     }
                                 ],
-                            }
+                            },
                         },
                     }
                 },


### PR DESCRIPTION
Compounds should be set to an aliquot (Well) even if all information is not present.  This change introduces more flexibility to set parameters associated with compounds to a given Well.