### PR TITLE
fix: `millimol` -> `millimole`

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -423,7 +423,7 @@ class Well(EntityPropertiesMixin):
                             compound[expected_params[k]] = compound.pop(k)
                         elif k == "concentration":
                             try:
-                                conc = Unit(compound.pop(k), "millimol/liter")
+                                conc = Unit(compound.pop(k), "millimole/liter")
                             except (UnitError):
                                 conc = None
                             compound[expected_params[k]] = conc

--- a/test/manifest_test.py
+++ b/test/manifest_test.py
@@ -804,7 +804,7 @@ class TestManifest(object):
                 "molecular_weight": Unit(100, "g/mol"),
                 "smiles": "CCCC",
                 "solubility_flag": False,
-                "concentration": Unit(10, "millimol/liter"),
+                "concentration": Unit(10, "millimole/liter"),
             }
         ]
         expected_compounds_list_default = [


### PR DESCRIPTION
Fix a typo we introduced when creating a concentration unit