### PR TITLE
Enhanced error message(s) when Well.set_volume() exceeds maximum allowed

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -255,11 +255,11 @@ class Well(EntityPropertiesMixin):
         if v > max_vol:
             containerIdInfo = ""
             if self.container.id is not None and len(self.container.id) > 0:
-                containerIdInfo = "with container id [" + self.container.id + "]"
+                containerIdInfo = " with container id " + self.container.id
 
             raise ValueError(
-                f"Failure at container [{self.container.name}] {containerIdInfo} "
-                f"when setting the volume for well [{self.index}]: "
+                f"Failure at container '{self.container.name}'{containerIdInfo} "
+                f"when setting the volume for well {self.index}: "
                 f"Theoretical volume [{v}] to be set exceeds maximum well "
                 f"volume [{max_vol}]."
             )

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -255,7 +255,7 @@ class Well(EntityPropertiesMixin):
         if v > max_vol:
             containerIdInfo = ""
             if self.container.id:
-                containerIdInfo = " with container id " + self.container.id
+                containerIdInfo = f" with container ID: {self.container.id}"
 
             raise ValueError(
                 f"Failure at container '{self.container.name}'{containerIdInfo} "

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -258,10 +258,9 @@ class Well(EntityPropertiesMixin):
                 containerIdInfo = f" with container ID: {self.container.id}"
 
             raise ValueError(
-                f"Failure at container '{self.container.name}'{containerIdInfo} "
-                f"when setting the volume for well {self.index}: "
                 f"Theoretical volume [{v}] to be set exceeds maximum well "
-                f"volume [{max_vol}]."
+                f"volume [{max_vol}] for container '{self.container.name}'{containerIdInfo} "
+                f"when setting the volume for well {self.index}."
             )
 
         self.volume = v

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -254,7 +254,7 @@ class Well(EntityPropertiesMixin):
         max_vol = self.container.container_type.true_max_vol_ul
         if v > max_vol:
             containerIdInfo = ""
-            if self.container.id is not None and len(self.container.id) > 0:
+            if self.container.id:
                 containerIdInfo = " with container id " + self.container.id
 
             raise ValueError(

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -253,10 +253,17 @@ class Well(EntityPropertiesMixin):
         v = Unit(vol)
         max_vol = self.container.container_type.true_max_vol_ul
         if v > max_vol:
+            containerIdInfo = ""
+            if self.container.id is not None and len(self.container.id) > 0:
+                containerIdInfo = "with container id [" + self.container.id + "]"
+
             raise ValueError(
-                f"Theoretical volume {v} to be set exceeds maximum well "
-                f"volume {max_vol}."
+                f"Failure at container [{self.container.name}] {containerIdInfo} "
+                f"when setting the volume for well [{self.index}]: "
+                f"Theoretical volume [{v}] to be set exceeds maximum well "
+                f"volume [{max_vol}]."
             )
+
         self.volume = v
         return self
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ test_deps = [
 
 doc_deps = [
     "releases>=1.6.3, <2",
+    "Jinja2<3.1",
     "Sphinx>=2.4, <3",
     "sphinx_rtd_theme>=0.4.3, <1",
     "semantic-version==2.6.0",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ test_deps = [
 
 doc_deps = [
     "releases>=1.6.3, <2",
-    "Jinja2<3.1",
     "Sphinx>=2.4, <3",
     "sphinx_rtd_theme>=0.4.3, <1",
     "semantic-version==2.6.0",

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -212,15 +212,33 @@ class TestWellVolume(HasDummyContainers):
             == dummy_384.container_type.well_volume_ul
         )
 
-    def test_echo_max_vol(self):
+    @pytest.mark.parametrize("test_containerid", [None, "ct1gkv7q3nbbd4j"])
+    def test_echo_max_vol(self, test_containerid):
+        test_container_name = "echo"
+        test_well_index = 0
+        test_well_vol_max = "135"
+        test_well_vol_to_set = "136"
+
         from autoprotocol.protocol import Protocol
 
         p = Protocol()
-        echo_w = p.ref("echo", None, "384-echo", discard=True).well(0)
-        echo_w.set_volume("135:microliter")
+        echo_w = p.ref(
+            test_container_name, test_containerid, "384-echo", discard=True
+        ).well(test_well_index)
+        echo_w.set_volume(test_well_vol_max + ":microliter")
         assert echo_w.volume == Unit(135, "microliter")
-        with pytest.raises(ValueError):
-            echo_w.set_volume("136:microliter")
+
+        with pytest.raises(ValueError) as the_error:
+            echo_w.set_volume(test_well_vol_to_set + ":microliter")
+
+        assert the_error is not None
+        error_msg = str(the_error.value)
+        assert test_container_name in error_msg
+        assert str(test_well_index) in error_msg
+        assert test_well_vol_to_set in error_msg
+        assert test_well_vol_max in error_msg
+        if test_containerid:
+            assert test_containerid in error_msg
 
 
 class TestWellName(HasDummyContainers):


### PR DESCRIPTION
When Well.set_volume() exceeds maximum allowed, the error message returned should include Container name, ID (if available) and the Well index number.

** STDV Internal Only **
(The comment below may be removed before merge to origin repo due to the internal STDV-only info)
Ticket: https://strateos.atlassian.net/browse/STDV-823
Test: tox script validation.