### PR TITLE
Revert "release version 8.0.0"

### DIFF
--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "8.0.0"
+__version__ = "7.15.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,10 +2,7 @@
 Changelog
 =========
 
-* :release:`8.0.0 <2022-11-16>`
-* :feature:`358` Dataclass enhancements to support objects schema-ready and de/serialization
-* :support:`360` typing for Protocol.instruction() methods
-* :feature:`359` Depriciate Python 3.6
+* :feature:`35X` Depriciate Python 3.6
 
 * :release:`7.15.1 <2022-10-27>`
 * :feature:`350` update: set pump_override_volume to default to None


### PR DESCRIPTION
Reverts autoprotocol/autoprotocol-python#361
Not building and publishing due to 
```
 UserWarning: The version specified ('"""Maintains current version of package"""\n__version__ = "8.0.0"\n') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % version
