### PR TITLE
fix(pre-commit-hook): isort incompatiability with latest poetry version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: black
         language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.9.3
+    rev: 5.11.5
     hooks:
       - id: isort
 -   repo: https://github.com/pycqa/pylint


### PR DESCRIPTION
CI pipeline not passing due to known issue https://github.com/tox-dev/tox/pull/2908. The latest poetry version is colliding with version of isort. The pre-commit-hook installs both making the lint CI step fail.