### PR TITLE
SCIENG-175 Acoustic Transfer property overwrite fix and warning silencer

### DIFF
--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -71,7 +71,7 @@ class EntityPropertiesMixin:
         self.properties = properties.copy()
         return self
 
-    def add_properties(self, properties, silence_warnings=False):
+    def add_properties(self, properties):
         """
         Add properties to the properties attribute of an entity (ie: Container or Well).
 
@@ -83,8 +83,6 @@ class EntityPropertiesMixin:
         ----------
         properties : dict
             Dictionary of properties to add to an entity.
-        silence_warnings : bool
-            Silence warnings when overwriting existing properties
 
         Returns
         -------
@@ -98,12 +96,9 @@ class EntityPropertiesMixin:
             if key in self.properties:
                 if isinstance(current_value, list) and isinstance(new_value, list):
                     current_value.extend(new_value)
-                elif silence_warnings:
-                    self.properties[key] = new_value
                 else:
                     message = (
-                        f"Overwriting existing property {key} for {self}. To silence this warning, set"
-                        f" silence_warnings=True"
+                        f"Overwriting existing property {key} for {self}."
                     )
                     warnings.warn(message=message)
                     self.properties[key] = new_value

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1,5 +1,3 @@
-# pylint: skip-file
-
 """
 Container, Well, WellGroup objects and associated functions
 

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -71,7 +71,7 @@ class EntityPropertiesMixin:
         self.properties = properties.copy()
         return self
 
-    def add_properties(self, properties):
+    def add_properties(self, properties, silence_warnings=False):
         """
         Add properties to the properties attribute of an entity (ie: Container or Well).
 
@@ -82,19 +82,24 @@ class EntityPropertiesMixin:
         Parameters
         ----------
         properties : dict
-            Dictionary of properties to add to a entity.
+            Dictionary of properties to add to an entity.
+        silence_warnings : bool
+            Silence warnings when overwriting existing properties
 
         Returns
         -------
         self
             Container or Well with modified properties
         """
+
         self.validate_properties(properties)
         for key, new_value in properties.items():
             current_value = self.properties.get(key)
             if key in self.properties:
                 if isinstance(current_value, list) and isinstance(new_value, list):
                     current_value.extend(new_value)
+                elif silence_warnings:
+                    self.properties[key] = new_value
                 else:
                     message = f"Overwriting existing property {key} for {self}"
                     warnings.warn(message=message)

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -101,7 +101,8 @@ class EntityPropertiesMixin:
                 elif silence_warnings:
                     self.properties[key] = new_value
                 else:
-                    message = f"Overwriting existing property {key} for {self}"
+                    message = f"Overwriting existing property {key} for {self}. To silence this warning, set" \
+                              f" silence_warnings=True"
                     warnings.warn(message=message)
                     self.properties[key] = new_value
             else:

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """
 Container, Well, WellGroup objects and associated functions
 

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -103,8 +103,10 @@ class EntityPropertiesMixin:
                 elif silence_warnings:
                     self.properties[key] = new_value
                 else:
-                    message = f"Overwriting existing property {key} for {self}. To silence this warning, set" \
-                              f" silence_warnings=True"
+                    message = (
+                        f"Overwriting existing property {key} for {self}. To silence this warning, set"
+                        f" silence_warnings=True"
+                    )
                     warnings.warn(message=message)
                     self.properties[key] = new_value
             else:

--- a/autoprotocol/container.py
+++ b/autoprotocol/container.py
@@ -97,9 +97,7 @@ class EntityPropertiesMixin:
                 if isinstance(current_value, list) and isinstance(new_value, list):
                     current_value.extend(new_value)
                 else:
-                    message = (
-                        f"Overwriting existing property {key} for {self}."
-                    )
+                    message = f"Overwriting existing property {key} for {self}."
                     warnings.warn(message=message)
                     self.properties[key] = new_value
             else:

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1,5 +1,3 @@
-# pylint: skip-file
-
 """
 Module containing the main `Protocol` object and associated functions
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """
 Module containing the main `Protocol` object and associated functions
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1677,7 +1677,7 @@ class Protocol:
             if v > Unit(0, "microliter"):
                 transfers.append(xfer)
             if self.propagate_properties:
-                d.set_properties(s.properties)
+                d.add_properties(s.properties, silence_warnings=True)
 
         if not transfers:
             raise RuntimeError(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -8170,7 +8170,7 @@ class Protocol:
 
             x_distance = abs(point_a[0] - point_b[0])
             y_distance = abs(point_a[1] - point_b[1])
-            return sqrt(x_distance ** 2 + y_distance ** 2)
+            return sqrt(x_distance**2 + y_distance**2)
 
         # Check validity of Well inputs
         if not isinstance(source, Well):

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1677,9 +1677,7 @@ class Protocol:
             if v > Unit(0, "microliter"):
                 transfers.append(xfer)
             if self.propagate_properties:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    d.add_properties(s.properties)
+                d.add_properties(s.properties)
 
         if not transfers:
             raise RuntimeError(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1677,7 +1677,9 @@ class Protocol:
             if v > Unit(0, "microliter"):
                 transfers.append(xfer)
             if self.propagate_properties:
-                d.add_properties(s.properties, silence_warnings=True)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    d.add_properties(s.properties)
 
         if not transfers:
             raise RuntimeError(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -8170,7 +8170,7 @@ class Protocol:
 
             x_distance = abs(point_a[0] - point_b[0])
             y_distance = abs(point_a[1] - point_b[1])
-            return sqrt(x_distance**2 + y_distance**2)
+            return sqrt(x_distance ** 2 + y_distance ** 2)
 
         # Check validity of Well inputs
         if not isinstance(source, Well):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`383` Propagating properties now adds instead of sets for acoustic spread
+
 * :release: `10.0.0 <2023-02-02>`
 * :support: `381` Recommit changes to version 10.0.0
 

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -1,5 +1,6 @@
 # pragma pylint: disable=missing-docstring,protected-access
 # pragma pylint: disable=attribute-defined-outside-init
+# pylint: skip-file
 import warnings
 
 import pytest

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -1,6 +1,5 @@
 # pragma pylint: disable=missing-docstring,protected-access
 # pragma pylint: disable=attribute-defined-outside-init
-# pylint: skip-file
 import warnings
 
 import pytest

--- a/test/protocol_test.py
+++ b/test/protocol_test.py
@@ -1432,8 +1432,11 @@ class TestAcousticTransfer(object):
         echo.well(0).set_volume("2:microliter")
         echo.well(0).set_properties({"test_well_property": True})
         dest.well(0).set_properties({"test_well_property": False})
+        dest.well(0).set_properties({"test_well_existing_property": True})
         p.acoustic_transfer(echo.well(0), dest.wells(0, 1), "50:nanoliter")
         echo_prop = echo.well(0).properties["test_well_property"]
+        # Test previous property
+        assert dest.well(0).properties["test_well_existing_property"]
         # Tests property overwrite
         assert echo_prop == dest.well(0).properties["test_well_property"]
         # Tests new property


### PR DESCRIPTION
- Fixes bug of unrelated property deletion when propagating new properties via acoustic transfer.
- Allows the use of a kwarg in `AcousticTransfer.add_properties(self, properties, silence_warnings=False)` to silence the "overwriting property" warning. 