### PR TITLE
Release Appy v10.1.0

### DIFF
--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.0.0"
+__version__ = "10.1.0"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :feature:`383` Propagating properties now adds instead of sets for acoustic spread
+* :release: `10.1.0 <2023-02-15>`
+* :feature: `383` Propagating properties now adds instead of sets for acoustic spread
 
 * :release: `10.0.0 <2023-02-02>`
 * :support: `381` Recommit changes to version 10.0.0


### PR DESCRIPTION
Update changelog and prepare for new release of Autoprotocol-python version 10.1.0