### PR TITLE
SCIENG-186: Release APpy with new `96-deep-kf` params

### DIFF
--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.1.0"
+__version__ = "10.1.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 =========
 Changelog
 =========
-* :release: `10.1.0 <2023-02-07>`
+* :release: `10.1.1 <2023-02-23>`
 * :feature: `378` Adjust `96-deep-kf` and `96-v-kf` container types `true_max_vol` to 1.8mL and
                     added validations in `MagBuilders` class such that plates being put onto KF
                     device do not exceed working vol with comb


### PR DESCRIPTION
Adjusted `96-deep-kf` and `96-v-kf` container types `true_max_vol` to 1.8mL and added validations in `MagBuilders` class such that plates being put onto KF device do not exceed working vol with comb