### PR TITLE
fix: magnetic transfer invalid well volume check

### DIFF
--- a/autoprotocol/instruction.py
+++ b/autoprotocol/instruction.py
@@ -234,8 +234,8 @@ class MagneticTransfer(Instruction):
         "96-pcr": ["96-pcr", "96-v-kf", "96-flat", "96-flat-uv"],
     }
     working_vols: dict = {
-        "96-v-kf": "200:microliter",
-        "96-deep-kf": "1000:microliter",
+        "96-v-kf": Unit(200, "microliter"),
+        "96-deep-kf": Unit(1000, "microliter"),
     }
 
     def __init__(self, groups, magnetic_head):
@@ -261,7 +261,8 @@ class MagneticTransfer(Instruction):
             w
             for container in containers
             for w in container.all_wells()
-            if w.volume and w.volume > self.working_vols[container.container_type]
+            if w.volume
+            and w.volume > self.working_vols[container.container_type.shortname]
         ]
         if wells_with_invalid_volumes:
             non_valid_container_working_vols = [

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.2.0"
+__version__ = "10.2.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,9 @@
 =========
 Changelog
 =========
+* :release: `10.2.1 <2023-02-27>`
+* :bug:`387` Fix Instruction::MagneticTransfer invalid volume detection
+
 * :release: `10.2.0 <2023-02-24>`
 * :support:`385` Further updates for dataclass compatibility
 


### PR DESCRIPTION
This fixes a recent change to well volume checks when doing magnetic transfers. This PR also prepares for release of v10.2.1, patching the bug.

Please merge and release once approved, thank you!