### PR TITLE
Revert rec tip type assignment

### DIFF
--- a/autoprotocol/liquid_handle/transfer.py
+++ b/autoprotocol/liquid_handle/transfer.py
@@ -102,10 +102,6 @@ class Transfer(LiquidHandleMethod):
         self._source_liquid = None
         self._destination_liquid = None
 
-    def _rec_tip_type(self, volume: Unit):
-        self.tip_type = super(Transfer, self)._rec_tip_type(volume=volume)
-        return self.tip_type
-
     def _has_calibration(self):
         liquids = [self._source_liquid, self._destination_liquid]
         return any(_ and _._has_calibration() for _ in liquids)

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.2.2"
+__version__ = "10.2.3"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release: `10.2.3 <2023-04-03>`
+* :bug:`391` Revert rec_tip_type implementation
+
 * :release: `10.2.2 <2023-02-28>`
 * :bug:`389` Adding unit_as_strings_factory to fix Unit serialization expected as str not dict
 * :bug:`389` Fix DispenseColumn serialization prior to constructing Dispense Instruction


### PR DESCRIPTION
Identified an error scheduling runs that contained liquid transfer instructions. This reverts a recently introduced method.

Previous behavior called `_rec_tip_type` from the parent class of `Transfer` but didn't assign it to self.tip_type

Scheduled a run and confirmed this fixes the error.