### PR TITLE
SCIENG-223: Update dependencies to allow for mantis liquid handle dispense

### DIFF
--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1536,7 +1536,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         chip_material: Optional[str] = None,
         nozzle: Optional[str] = None,
         diaphragm: Optional[int] = None,
-        nozzle_size: Optional[Unit] or Optional[str] = None,
+        nozzle_size: Optional[Union[Unit, str]] = None,
         tubing: Optional[str] = None,
         z_drop: Optional[Unit] or Optional[str] = None,
         viscosity: Optional[str] = None,

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1539,7 +1539,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         nozzle_size: Optional[Unit] = None,
         tubing: Optional[str] = None,
         z_drop: Optional[Unit] = None,
-        viscosity: Optional[str] = None
+        viscosity: Optional[str] = None,
     ):
         """Helper for building device level mode_params
 
@@ -1590,14 +1590,14 @@ class LiquidHandleBuilders(InstructionBuilders):
             If chip_material is not None or in the allowable list of tempest chip materials
         """
         params: dict = {
-           "model": model,
-           "material": chip_material,
-           "nozzle": nozzle,
-           "diaphragm": diaphragm,
-           "nozzle_size": nozzle_size,
-           "tubing": tubing,
-           "z_drop": z_drop,
-           "viscosity": viscosity
+            "model": model,
+            "material": chip_material,
+            "nozzle": nozzle,
+            "diaphragm": diaphragm,
+            "nozzle_size": nozzle_size,
+            "tubing": tubing,
+            "z_drop": z_drop,
+            "viscosity": viscosity,
         }
         if device not in ["x_mantis", "x_tempest_chip"]:
             raise ValueError(

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1568,11 +1568,6 @@ class LiquidHandleBuilders(InstructionBuilders):
         viscosity: Optional[String]
             one of "1", "2-5", "6-10", "11-20", "21-25"
 
-        Returns
-        -------
-        dict
-            device_mode_params for a LiquidHandle instruction
-
         Raises
         ------
         ValueError

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1568,6 +1568,11 @@ class LiquidHandleBuilders(InstructionBuilders):
         viscosity: Optional[String]
             one of "1", "2-5", "6-10", "11-20", "21-25"
 
+        Returns
+        -------
+        dict
+            device_mode_params for a LiquidHandle instruction
+
         Raises
         ------
         ValueError
@@ -1598,7 +1603,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         return {device: device_dict}
 
     @staticmethod
-    def validate_device_params(device: str, device_dict: dict):
+    def validate_device_params(device: str, device_dict: dict) -> None:
         """
         Helper validation function to validate device liquid handling params
         Parameters
@@ -1607,11 +1612,6 @@ class LiquidHandleBuilders(InstructionBuilders):
             either x_mantis or x_tempest_chip
         device_dict: dict
             Dictionary of all device params, as seen in function device_mode_params
-
-        Returns
-        -------
-        dict
-            default_dict for the specified device
 
         Raises
         ------

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1548,13 +1548,13 @@ class LiquidHandleBuilders(InstructionBuilders):
 
         Parameters
         ----------
-        device: string
+        device: str
             x_tempest_chip or x_mantis
-        model: string, optional
+        model: Optional[str]
             Tempest chip or mantis model.
-        chip_material: string, optional
+        chip_material: Optional[str]
             Material that the tempest chip is made of.
-        nozzle: string, optional
+        nozzle: Optional[str]
             Type of chip nozzle for tempest.
         diaphragm: Optional[Integer]
             any integer between 0 and 100, inclusive

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1562,6 +1562,7 @@ class LiquidHandleBuilders(InstructionBuilders):
             one of "0.1:mm", "0.2:mm", "0.5:mm"
         tubing: Optional[String]
             one of "LV", "HV", "P200", "P1000"
+            TODO: support that source is pipette-tip type
         z_drop: Optional[Unit[Length]]
             within the range: 0:mm - 100:mm, inclusive
         viscosity: Optional[String]

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1666,7 +1666,10 @@ class LiquidHandleBuilders(InstructionBuilders):
                         compare_val = Unit(value)
                     else:
                         compare_val = value
-                    if accepted_range[0] > compare_val > accepted_range[1]:
+                    if (
+                        compare_val < accepted_range[0]
+                        or compare_val > accepted_range[1]
+                    ):
                         error_values.update({key: value})
                 # The following logic should be able to support container_type.shortname
                 elif key == "tubing":

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1589,6 +1589,16 @@ class LiquidHandleBuilders(InstructionBuilders):
         ValueError
             If chip_material is not None or in the allowable list of tempest chip materials
         """
+        params: dict = {
+           "model": model,
+           "material": chip_material,
+           "nozzle": nozzle,
+           "diaphragm": diaphragm,
+           "nozzle_size": nozzle_size,
+           "tubing": tubing,
+           "z_drop": z_drop,
+           "viscosity": viscosity
+        }
         if device not in ["x_mantis", "x_tempest_chip"]:
             raise ValueError(
                 f"Device is {device}. It must be: [x_tempest_chip, x_mantis]"
@@ -1618,26 +1628,10 @@ class LiquidHandleBuilders(InstructionBuilders):
                 "viscosity": None,
             }
         device_dict: dict = {}
-        if any([
-            model,
-            chip_material,
-            nozzle,
-            diaphragm,
-            nozzle_size,
-            tubing,
-            z_drop,
-            viscosity
-        ]):
-            device_dict.update({
-                "model": model or default_params["model"],
-                "material": chip_material or default_params["material"],
-                "nozzle": nozzle or default_params["nozzle"],
-                "diaphragm": diaphragm or default_params["diaphragm"],
-                "nozzle_size": nozzle_size or default_params["nozzle_size"],
-                "tubing": tubing or default_params["tubing"],
-                "z_drop": z_drop or default_params["z_drop"],
-                "viscosity": viscosity or default_params["viscosity"],
-            })
+        if any(params.values()):
+            for key, value in params.items():
+                device_dict.update({key: value or default_params[key]})
+
         LiquidHandleBuilders.validate_device_params(device, device_dict)
 
         return {device: device_dict}

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1603,41 +1603,21 @@ class LiquidHandleBuilders(InstructionBuilders):
             raise ValueError(
                 f"Device is {device}. It must be: [x_tempest_chip, x_mantis]"
             )
-        if device == "x_mantis":
-            # If device is mantis, set default params
-            default_params: dict = {
-                "model": "high_volume",
-                "material": None,
-                "nozzle": None,
-                "diaphragm": 0,
-                "nozzle_size": "0.1:mm",
-                "tubing": "LV",
-                "z_drop": "0.0:mm",
-                "viscosity": "1",
-            }
-        else:
-            # Otherwise, default to tempest default params
-            default_params: dict = {
-                "model": "high_volume",
-                "material": "pfe",
-                "nozzle": "standard",
-                "diaphragm": None,
-                "nozzle_size": None,
-                "tubing": None,
-                "z_drop": None,
-                "viscosity": None,
-            }
+
+        default_params = LiquidHandleBuilders.validate_device_params(device, params)
+
         device_dict: dict = {}
         if any(params.values()):
             for key, value in params.items():
-                device_dict.update({key: value or default_params[key]})
-
-        LiquidHandleBuilders.validate_device_params(device, device_dict)
+                if key not in default_params:
+                    device_dict.update({key: value or None})
+                else:
+                    device_dict.update({key: value or default_params[key]})
 
         return {device: device_dict}
 
     @staticmethod
-    def validate_device_params(device: str, device_dict: dict) -> None:
+    def validate_device_params(device: str, device_dict: dict) -> dict:
         """
         Helper validation function to validate device liquid handling params
         Parameters
@@ -1669,7 +1649,7 @@ class LiquidHandleBuilders(InstructionBuilders):
             accepted_params: dict = {
                 "model": ["high_volume"],
                 "nozzle": ["standard"],
-                "material": ["silicone", "pfe"],
+                "material": ["pfe", "silicone"],
             }
         else:
             raise ValueError(
@@ -1691,6 +1671,12 @@ class LiquidHandleBuilders(InstructionBuilders):
             raise ValueError(
                 f"Incorrect params: {error_values}. It must be {accepted_params}"
             )
+
+        default_dict: dict = {}
+        for key, value in accepted_params.items():
+            default_dict.update({key: value[0]})
+
+        return default_dict
 
     @staticmethod
     def move_rate(

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1582,12 +1582,6 @@ class LiquidHandleBuilders(InstructionBuilders):
         ------
         ValueError
             If device is not of the following: [x_tempest_chip, x_mantis]
-        ValueError
-            If model is not None or "high_volume"
-        ValueError
-            If nozzle is not None or "standard"
-        ValueError
-            If chip_material is not None or in the allowable list of tempest chip materials
         """
         params: dict = {
             "model": model,
@@ -1673,6 +1667,7 @@ class LiquidHandleBuilders(InstructionBuilders):
             )
 
         default_dict: dict = {}
+        # Default to the first value in the accepted params dict
         for key, value in accepted_params.items():
             default_dict.update({key: value[0]})
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1538,7 +1538,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         diaphragm: Optional[int] = None,
         nozzle_size: Optional[Union[Unit, str]] = None,
         tubing: Optional[str] = None,
-        z_drop: Optional[Unit] or Optional[str] = None,
+        z_drop: Optional[Union[Unit, str]] = None,
         viscosity: Optional[str] = None,
     ):
         """Helper for building device level mode_params

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -23,7 +23,7 @@ See Also
 Instruction
     Instructions corresponding to each of the builders
 """
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterable  # pylint: disable=no-name-in-module
 from functools import reduce
 from numbers import Number

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1562,12 +1562,6 @@ class LiquidHandleBuilders(InstructionBuilders):
             one of "0.1:mm", "0.2:mm", "0.5:mm"
         tubing: Optional[String]
             one of "LV", "HV", "P200", "P1000"
-            TODO: How do we want to handle these tip types?
-            In the future, we're going to have tempest source support
-            this new tip type container type which will get a shortname
-            akin to `pipette-tip-p200` or something. If we align these
-            two values to that shortname, we can just pass it in via
-            `source_container.container_type.shortname`
         z_drop: Optional[Unit[Length]]
             within the range: 0:mm - 100:mm, inclusive
         viscosity: Optional[String]
@@ -1660,6 +1654,14 @@ class LiquidHandleBuilders(InstructionBuilders):
                 if key == "z_drop" or key == "diaphragm":
                     accepted_range: List = list(accepted_params[key])
                     if value < accepted_range[0] or value > accepted_range[1]:
+                        error_values.update({key: value})
+                # The following logic should be able to support container_type.shortname
+                elif key == "tubing":
+                    accepted_val: bool = False
+                    for tubing_val in accepted_params[key]:
+                        if tubing_val in value.upper():
+                            accepted_val = True
+                    if not accepted_val:
                         error_values.update({key: value})
                 else:
                     if value not in accepted_params[key]:

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1625,6 +1625,8 @@ class LiquidHandleBuilders(InstructionBuilders):
         ValueError
             If input device_dict values are not of the accepted
             params for the input device
+        KeyError
+            If input device_dict key is not in accepted_params keys
         """
         if device == "x_mantis":
             # If device is mantis, set accepted params

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1602,9 +1602,9 @@ class LiquidHandleBuilders(InstructionBuilders):
 
         device_dict: dict = {}
         if any(params.values()):
-            for key, value in params.items():
+            for key, value in default_params.items():
                 if key in default_params:
-                    device_dict.update({key: value or default_params[key]})
+                    device_dict.update({key: params[key] or value})
 
         return {device: device_dict}
 

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1558,12 +1558,12 @@ class LiquidHandleBuilders(InstructionBuilders):
             Type of chip nozzle for tempest.
         diaphragm: Optional[Integer]
             any integer between 0 and 100, inclusive
-        nozzle_size: Optional[Unit[Length]]
+        nozzle_size: Optional[Unit[Length]] or Optional[str]
             one of "0.1:mm", "0.2:mm", "0.5:mm"
         tubing: Optional[String]
             one of "LV", "HV", "P200", "P1000"
             TODO: support that source is pipette-tip type
-        z_drop: Optional[Unit[Length]]
+        z_drop: Optional[Unit[Length]] or Optional[str]
             within the range: 0:mm - 100:mm, inclusive
         viscosity: Optional[String]
             one of "1", "2-5", "6-10", "11-20", "21-25"

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -23,7 +23,7 @@ See Also
 Instruction
     Instructions corresponding to each of the builders
 """
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from collections.abc import Iterable  # pylint: disable=no-name-in-module
 from functools import reduce
 from numbers import Number
@@ -1578,7 +1578,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         ValueError
             If device is not of the following: [x_tempest_chip, x_mantis]
         """
-        params: dict = {
+        params: OrderedDict = {
             "model": model,
             "material": chip_material,
             "nozzle": nozzle,
@@ -1593,18 +1593,17 @@ class LiquidHandleBuilders(InstructionBuilders):
                 f"Device is {device}. It must be: [x_tempest_chip, x_mantis]"
             )
 
-        default_params = LiquidHandleBuilders.validate_device_params(device, params)
+        LiquidHandleBuilders.validate_device_params(device, params)
 
         device_dict: dict = {}
-        if any(params.values()):
-            for key, value in default_params.items():
-                if key in default_params:
-                    device_dict.update({key: params[key] or value})
+        for key, value in params.items():
+            if value or isinstance(value, int):
+                device_dict.update({key: value})
 
         return {device: device_dict}
 
     @staticmethod
-    def validate_device_params(device: str, device_dict: dict) -> dict:
+    def validate_device_params(device: str, device_dict: dict):
         """
         Helper validation function to validate device liquid handling params
         Parameters
@@ -1672,13 +1671,6 @@ class LiquidHandleBuilders(InstructionBuilders):
             raise ValueError(
                 f"Incorrect params: {error_values}. It must be {accepted_params}"
             )
-
-        default_dict: dict = {}
-        # Default to the first value in the accepted params dict
-        for key, value in accepted_params.items():
-            default_dict.update({key: value[0]})
-
-        return default_dict
 
     @staticmethod
     def move_rate(

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1671,14 +1671,6 @@ class LiquidHandleBuilders(InstructionBuilders):
                         or compare_val > accepted_range[1]
                     ):
                         error_values.update({key: value})
-                # The following logic should be able to support container_type.shortname
-                elif key == "tubing":
-                    accepted_val: bool = False
-                    for tubing_val in accepted_params[key]:
-                        if tubing_val in value.upper():
-                            accepted_val = True
-                    if not accepted_val:
-                        error_values.update({key: value})
                 elif key == "nozzle_size":
                     if (
                         isinstance(value, str)

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1618,6 +1618,12 @@ class LiquidHandleBuilders(InstructionBuilders):
             either x_mantis or x_tempest_chip
         device_dict: dict
             Dictionary of all device params, as seen in function device_mode_params
+
+        Returns
+        -------
+        dict
+            default_dict for the specified device
+
         Raises
         ------
         ValueError

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1603,9 +1603,7 @@ class LiquidHandleBuilders(InstructionBuilders):
         device_dict: dict = {}
         if any(params.values()):
             for key, value in params.items():
-                if key not in default_params:
-                    device_dict.update({key: value or None})
-                else:
+                if key in default_params:
                     device_dict.update({key: value or default_params[key]})
 
         return {device: device_dict}

--- a/autoprotocol/builders.py
+++ b/autoprotocol/builders.py
@@ -1666,10 +1666,7 @@ class LiquidHandleBuilders(InstructionBuilders):
                         compare_val = Unit(value)
                     else:
                         compare_val = value
-                    if (
-                        compare_val < accepted_range[0]
-                        or compare_val > accepted_range[1]
-                    ):
+                    if accepted_range[0] > compare_val > accepted_range[1]:
                         error_values.update({key: value})
                 # The following logic should be able to support container_type.shortname
                 elif key == "tubing":

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1038,7 +1038,7 @@ class Protocol:
         nozzle_size: Optional[Unit] = None,
         tubing: Optional[str] = None,
         z_drop: Optional[Unit] = None,
-        viscosity: Optional[str] = None
+        viscosity: Optional[str] = None,
     ):
         """Generates a liquid_handle dispense
 
@@ -1499,7 +1499,7 @@ class Protocol:
             nozzle_size=nozzle_size,
             tubing=tubing,
             z_drop=z_drop,
-            viscosity=viscosity
+            viscosity=viscosity,
         )
         return self._append_and_return(
             LiquidHandle(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -115,9 +115,9 @@ from .unit import Unit, UnitError
 from .util import (
     _check_container_type_with_shape,
     _validate_as_instance,
+    _validate_liha_shape,
     is_valid_well,
     parse_unit,
-    _validate_liha_shape,
 )
 
 

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1036,7 +1036,7 @@ class Protocol:
         chip_material: Optional[str] = None,
         nozzle: Optional[str] = None,
         diaphragm: Optional[int] = None,
-        nozzle_size: Optional[Unit] = None,
+        nozzle_size: Optional[Union[Unit, str]] = None,
         tubing: Optional[str] = None,
         z_drop: Optional[Union[Unit, str]] = None,
         viscosity: Optional[str] = None,

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1030,7 +1030,7 @@ class Protocol:
         columns: int = 1,
         method: DispenseMethod = DispenseMethod,
         liquid: LiquidClass = LiquidClass,
-        device: Optional[str] = None,
+        device: Optional[str] = "x_tempest_chip",
         model: Optional[str] = None,
         chip_material: Optional[str] = None,
         nozzle: Optional[str] = None,
@@ -1207,6 +1207,8 @@ class Protocol:
         default_num_dispense_chips_in_source: int = 1
         default_max_num_dispense_chips: int = 12
         remaining_num_chips_to_specify = default_max_num_dispense_chips
+        if device == "x_mantis":
+            rows = 1
 
         def format_source_well(well: Well, num_chips: int) -> Tuple[Well, int]:
             return (well, num_chips)
@@ -1491,7 +1493,7 @@ class Protocol:
             # Update source volume
             source_location.add_volume(-total_volume_dispensed)
         device_mode_params = LiquidHandleBuilders.device_mode_params(
-            device=device or "x_tempest_chip",
+            device=device,
             model=model,
             chip_material=chip_material,
             nozzle=nozzle,

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -117,6 +117,7 @@ from .util import (
     _validate_as_instance,
     is_valid_well,
     parse_unit,
+    _validate_liha_shape,
 )
 
 
@@ -1207,8 +1208,7 @@ class Protocol:
         default_num_dispense_chips_in_source: int = 1
         default_max_num_dispense_chips: int = 12
         remaining_num_chips_to_specify = default_max_num_dispense_chips
-        if device == "x_mantis":
-            rows = 1
+        _validate_liha_shape(device, {"rows": rows, "columns": columns})
 
         def format_source_well(well: Well, num_chips: int) -> Tuple[Well, int]:
             return (well, num_chips)

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1092,7 +1092,7 @@ class Protocol:
             Tempest nozzle type, currently only support "standard".
             The three chip parameters: model, chip_material, and nozzle will be
             used in liquid handle mode_params to allow tempest chip specification.
-        diaphragm : int, optional
+        diaphragm : Optional[int]
             any integer between 0 and 100, inclusive
         nozzle_size : Unit[Length], optional
             one of "0.1:mm", "0.2:mm", "0.5:mm".

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1030,9 +1030,15 @@ class Protocol:
         columns: int = 1,
         method: DispenseMethod = DispenseMethod,
         liquid: LiquidClass = LiquidClass,
+        device: Optional[str] = None,
         model: Optional[str] = None,
         chip_material: Optional[str] = None,
         nozzle: Optional[str] = None,
+        diaphragm: Optional[int] = None,
+        nozzle_size: Optional[Unit] = None,
+        tubing: Optional[str] = None,
+        z_drop: Optional[Unit] = None,
+        viscosity: Optional[str] = None
     ):
         """Generates a liquid_handle dispense
 
@@ -1074,6 +1080,8 @@ class Protocol:
             Integrates with the specified liquid to define a set of physical
             movements. If the number of Dispense classes specified is more than one
             then number specified must match the length of sources.
+        device: str
+            Device used for liquid_handle_dispense execution
         model : str, optional
             Tempest chip model, currently only support "high_volume".
         chip_material : str, optional
@@ -1083,6 +1091,20 @@ class Protocol:
             Tempest nozzle type, currently only support "standard".
             The three chip parameters: model, chip_material, and nozzle will be
             used in liquid handle mode_params to allow tempest chip specification.
+        diaphragm : int, optional
+            any integer between 0 and 100, inclusive
+        nozzle_size : Unit[Length], optional
+            one of "0.1:mm", "0.2:mm", "0.5:mm".
+            Default is "0.1:mm".
+        tubing: Optional[String]
+            one of "LV", "HV", "P200", "P1000".
+            Default is "LV"
+        z_drop: Optional[Unit[Length]]
+            within the range: 0:mm - 100:mm, inclusive.
+            Default is "0:mm"
+        viscosity: Optional[String]
+            one of "1", "2-5", "6-10", "11-20", "21-25".
+            Default is "1".
 
         Returns
         -------
@@ -1469,7 +1491,15 @@ class Protocol:
             # Update source volume
             source_location.add_volume(-total_volume_dispensed)
         device_mode_params = LiquidHandleBuilders.device_mode_params(
-            model=model, chip_material=chip_material, nozzle=nozzle
+            device=device or "x_tempest_chip",
+            model=model,
+            chip_material=chip_material,
+            nozzle=nozzle,
+            diaphragm=diaphragm,
+            nozzle_size=nozzle_size,
+            tubing=tubing,
+            z_drop=z_drop,
+            viscosity=viscosity
         )
         return self._append_and_return(
             LiquidHandle(

--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -1038,7 +1038,7 @@ class Protocol:
         diaphragm: Optional[int] = None,
         nozzle_size: Optional[Unit] = None,
         tubing: Optional[str] = None,
-        z_drop: Optional[Unit] = None,
+        z_drop: Optional[Union[Unit, str]] = None,
         viscosity: Optional[str] = None,
     ):
         """Generates a liquid_handle dispense

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -229,9 +229,6 @@ def _validate_liha_shape(device: str, shape: dict) -> None:
                     devices or if the provided shape is not valid for the
                     specified device.
 
-    Returns:
-        None
-
     Example:
         >>> _validate_liha_shape("x_mantis", {"rows": 1, "columns": 1})
         None

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -213,3 +213,22 @@ def _check_container_type_with_shape(container_type, shape):
             f"a full row consists of {format_columns} columns and a full "
             f"column consists of {format_rows} rows, but {shape} was specified."
         )
+
+
+def _validate_liha_shape(device: str, shape: dict) -> None:
+    """Validates LiHa shape for liquid handle dispense"""
+    accepted_shape = {}
+    if device == "x_mantis":
+        accepted_shape.update({"rows": 1, "columns": 1})
+    elif device == "x_tempest_chip":
+        accepted_shape.update({"rows": 8, "columns": 1})
+    else:
+        raise ValueError(
+            f"Device {device} is not in list of accepted devices "
+            f"[x_mantis, x_tempest_chip]"
+        )
+    if shape != accepted_shape:
+        raise ValueError(
+            f"Input LiHa shape: {shape}. "
+            f"Should be {accepted_shape} for device {device}."
+        )

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -216,7 +216,26 @@ def _check_container_type_with_shape(container_type, shape):
 
 
 def _validate_liha_shape(device: str, shape: dict) -> None:
-    """Validates LiHa shape for liquid handle dispense"""
+    """Validates LiHa shape for liquid handle dispense.
+
+    Args:
+        device (str): The LiHa device name. Currently supported devices are 
+                      "x_mantis" and "x_tempest_chip".
+        shape (dict): A dictionary containing the number of rows and columns
+                      for the LiHa shape. For example, {"rows": 8, "columns": 1}.
+
+    Raises:
+        ValueError: If the provided device name is not one of the supported 
+                    devices or if the provided shape is not valid for the 
+                    specified device.
+
+    Returns:
+        None
+
+    Example:
+        >>> _validate_liha_shape("x_mantis", {"rows": 1, "columns": 1})
+        None
+    """
     accepted_shape = {}
     if device == "x_mantis":
         accepted_shape.update({"rows": 1, "columns": 1})

--- a/autoprotocol/util.py
+++ b/autoprotocol/util.py
@@ -219,14 +219,14 @@ def _validate_liha_shape(device: str, shape: dict) -> None:
     """Validates LiHa shape for liquid handle dispense.
 
     Args:
-        device (str): The LiHa device name. Currently supported devices are 
+        device (str): The LiHa device name. Currently supported devices are
                       "x_mantis" and "x_tempest_chip".
         shape (dict): A dictionary containing the number of rows and columns
                       for the LiHa shape. For example, {"rows": 8, "columns": 1}.
 
     Raises:
-        ValueError: If the provided device name is not one of the supported 
-                    devices or if the provided shape is not valid for the 
+        ValueError: If the provided device name is not one of the supported
+                    devices or if the provided shape is not valid for the
                     specified device.
 
     Returns:

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.2.2"
+__version__ = "10.3.0"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 * :release: `10.3.0 <2023-03-24>`
 * :feature: `390` Support for Mantis `liquid_handle` dispense in `device_mode_params`
-* :feature: `392` Support for Mantis in `liquid_handle_dispense` method
+* :feature: `393` Support for Mantis in `liquid_handle_dispense` method
 
 * :release: `10.2.2 <2023-02-28>`
 * :bug:`389` Adding unit_as_strings_factory to fix Unit serialization expected as str not dict

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,9 @@
 =========
 Changelog
 =========
+* :release: `10.3.0 <2023-03-24>`
+* :feature: `390` Support for Mantis `liquid_handle` dispense in `device_mode_params`
+* :feature: `392` Support for Mantis in `liquid_handle_dispense` method
 
 * :release: `10.2.2 <2023-02-28>`
 * :bug:`389` Adding unit_as_strings_factory to fix Unit serialization expected as str not dict

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -1026,17 +1026,17 @@ class TestMantisDispenseMode:
                 diaphragm=101,
             )
         # Incorrect nozzle_size value
-        # with pytest.raises(ValueError):
-        #     self.protocol.liquid_handle_dispense(
-        #         source=self.tube.well(0),
-        #         destination=self.flat.well(0),
-        #         volume="5:uL",
-        #         rows=1,
-        #         columns=1,
-        #         liquid=ProteinBuffer,
-        #         device="x_mantis",
-        #         nozzle_size="0.3:mm",
-        #     )
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                nozzle_size="0.3:mm",
+            )
         # Incorrect tubing value
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -895,7 +895,7 @@ class TestLiquidHandleDispenseMode:
         assert instruction.data["mode_params"] == mode_params
 
     def test_mantis_other_params(self):
-        """ Tests mantis low_volume params """
+        """ Tests mantis low_volume params, still accepted"""
         instruction = self.protocol.liquid_handle_dispense(
             source=self.tube.well(0),
             destination=self.flat.well(0),

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -905,7 +905,7 @@ class TestLiquidHandleDispenseMode:
             model="low_volume",
             diaphragm=25,
             nozzle_size="0.1:mm",
-            tubing="LV",
+            tubing="P200",
             z_drop="0.2:mm",
             viscosity="1",
         )
@@ -915,7 +915,7 @@ class TestLiquidHandleDispenseMode:
                 "model": "low_volume",
                 "diaphragm": 25,
                 "nozzle_size": "0.1:mm",
-                "tubing": "LV",
+                "tubing": "P200",
                 "z_drop": "0.2:mm",
                 "viscosity": "1",
             }
@@ -996,7 +996,7 @@ class TestLiquidHandleDispenseMode:
                     model="high_volume",
                     diaphragm=101,
                     nozzle_size="0.3:mm",
-                    tubing="MV",
+                    tubing="LV",
                     z_drop="200.0:mm",
                     viscosity="1",
                 )
@@ -1011,7 +1011,7 @@ class TestLiquidHandleDispenseMode:
                     model="high_volume",
                     diaphragm=101,
                     nozzle_size="0.3:mm",
-                    tubing="MV",
+                    tubing="LV",
                     z_drop="0.0:mm",
                     viscosity="100",
                 )

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -856,6 +856,166 @@ class TestLiquidHandleDispenseMode:
                 nozzle="abc",
             )
 
+    def test_mantis_default_params(self):
+        """ Tests mantis default params """
+        instruction = self.protocol.liquid_handle_dispense(
+            source=self.tube.well(0),
+            destination=self.flat.well(0),
+            volume="5:uL",
+            liquid=ProteinBuffer,
+        )
+
+        assert "mode_params" not in instruction.data
+
+        instruction = self.protocol.liquid_handle_dispense(
+            source=self.tube.well(0),
+            destination=self.flat.well(0),
+            volume="5:uL",
+            liquid=ProteinBuffer,
+            device="x_mantis",
+            model="high_volume",
+            diaphragm=0,
+            nozzle_size="0.1:mm",
+            tubing="LV",
+            z_drop="0.0:mm",
+            viscosity="1"
+        )
+
+        mode_params = {
+            "x_mantis": {
+                "model": "high_volume",
+                "diaphragm": 0,
+                "nozzle_size": "0.1:mm",
+                "tubing": "LV",
+                "z_drop": "0.0:mm",
+                "viscosity": "1",
+            }
+        }
+
+        assert instruction.data["mode_params"] == mode_params
+
+    def test_mantis_other_params(self):
+        """ Tests mantis low_volume params """
+        instruction = self.protocol.liquid_handle_dispense(
+            source=self.tube.well(0),
+            destination=self.flat.well(0),
+            volume="5:uL",
+            liquid=ProteinBuffer,
+            device="x_mantis",
+            model="low_volume",
+            diaphragm=25,
+            nozzle_size="0.1:mm",
+            tubing="LV",
+            z_drop="0.2:mm",
+            viscosity="1"
+        )
+
+        mode_params = {
+            "x_mantis": {
+                "model": "low_volume",
+                "diaphragm": 25,
+                "nozzle_size": "0.1:mm",
+                "tubing": "LV",
+                "z_drop": "0.2:mm",
+                "viscosity": "1",
+            }
+        }
+
+        assert instruction.data["mode_params"] == mode_params
+
+    def test_mantis_bad_params(self):
+        """ Tests mantis bad params """
+        # Incorrect model param
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                model="mid_volume",
+                diaphragm=0,
+                nozzle_size="0.1:mm",
+                tubing="LV",
+                z_drop="0.0:mm",
+                viscosity="1"
+            )
+        # Incorrect diaphragm value
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                model="high_volume",
+                diaphragm=101,
+                nozzle_size="0.1:mm",
+                tubing="LV",
+                z_drop="0.0:mm",
+                viscosity="1"
+            )
+            # Incorrect nozzle_size value
+            with pytest.raises(ValueError):
+                self.protocol.liquid_handle_dispense(
+                    source=self.tube.well(0),
+                    destination=self.flat.well(0),
+                    volume="5:uL",
+                    liquid=ProteinBuffer,
+                    device="x_mantis",
+                    model="high_volume",
+                    diaphragm=101,
+                    nozzle_size="0.3:mm",
+                    tubing="LV",
+                    z_drop="0.0:mm",
+                    viscosity="1"
+                )
+            # Incorrect tubing value
+            with pytest.raises(ValueError):
+                self.protocol.liquid_handle_dispense(
+                    source=self.tube.well(0),
+                    destination=self.flat.well(0),
+                    volume="5:uL",
+                    liquid=ProteinBuffer,
+                    device="x_mantis",
+                    model="high_volume",
+                    diaphragm=101,
+                    nozzle_size="0.3:mm",
+                    tubing="MV",
+                    z_drop="0.0:mm",
+                    viscosity="1"
+                )
+            # Incorrect z_drop value
+            with pytest.raises(ValueError):
+                self.protocol.liquid_handle_dispense(
+                    source=self.tube.well(0),
+                    destination=self.flat.well(0),
+                    volume="5:uL",
+                    liquid=ProteinBuffer,
+                    device="x_mantis",
+                    model="high_volume",
+                    diaphragm=101,
+                    nozzle_size="0.3:mm",
+                    tubing="MV",
+                    z_drop="200.0:mm",
+                    viscosity="1"
+                )
+            # Incorrect viscosity value
+            with pytest.raises(ValueError):
+                self.protocol.liquid_handle_dispense(
+                    source=self.tube.well(0),
+                    destination=self.flat.well(0),
+                    volume="5:uL",
+                    liquid=ProteinBuffer,
+                    device="x_mantis",
+                    model="high_volume",
+                    diaphragm=101,
+                    nozzle_size="0.3:mm",
+                    tubing="MV",
+                    z_drop="0.0:mm",
+                    viscosity="100"
+                )
+
     def test_liquid_handle_volume_tracking(self):
         self.tube.well(0).set_volume("0:microliter")
 

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -952,7 +952,7 @@ class TestLiquidHandleDispenseMode:
 
     def test_mantis_bad_params(self):
         """Tests mantis bad params"""
-        # Incorrect model param and incorrect liha shape
+        # Incorrect model param and incorrect liha shape for mantis
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(
                 source=self.tube.well(0),

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -766,6 +766,8 @@ class TestLiquidHandleDispenseMode:
             }
         }
 
+        liha_shape = instruction.data["shape"]
+        assert liha_shape["rows"] == 8 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
         instruction = self.protocol.liquid_handle_dispense(
@@ -804,6 +806,9 @@ class TestLiquidHandleDispenseMode:
                 "model": "high_volume",
             }
         }
+
+        liha_shape = instruction.data["shape"]
+        assert liha_shape["rows"] == 8 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
     def test_tempest_bad_chip_param(self):
@@ -892,6 +897,8 @@ class TestLiquidHandleDispenseMode:
             }
         }
 
+        liha_shape = instruction.data["shape"]
+        assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
     def test_mantis_other_params(self):
@@ -921,6 +928,8 @@ class TestLiquidHandleDispenseMode:
             }
         }
 
+        liha_shape = instruction.data["shape"]
+        assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
     def test_mantis_bad_params(self):

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -936,6 +936,39 @@ class TestLiquidHandleDispenseMode:
         assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
+    def test_p200_shortname_params(self):
+        """Tests that pipette-tip-p200 is still accepted"""
+        instruction = self.protocol.liquid_handle_dispense(
+            source=self.tube.well(0),
+            destination=self.flat.well(0),
+            volume="5:uL",
+            rows=1,
+            columns=1,
+            liquid=ProteinBuffer,
+            device="x_mantis",
+            model="low_volume",
+            diaphragm=25,
+            nozzle_size="0.1:mm",
+            tubing="pipette-tip-p200",
+            z_drop="0.2:mm",
+            viscosity="1",
+        )
+
+        mode_params = {
+            "x_mantis": {
+                "model": "low_volume",
+                "diaphragm": 25,
+                "nozzle_size": "0.1:mm",
+                "tubing": "pipette-tip-p200",
+                "z_drop": "0.2:mm",
+                "viscosity": "1",
+            }
+        }
+
+        liha_shape = instruction.data["shape"]
+        assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
+        assert instruction.data["mode_params"] == mode_params
+
     def test_mantis_bad_params(self):
         """Tests mantis bad params"""
         # Incorrect model param and incorrect liha shape

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -876,6 +876,8 @@ class TestLiquidHandleDispenseMode:
             source=self.tube.well(0),
             destination=self.flat.well(0),
             volume="5:uL",
+            rows=1,
+            columns=1,
             liquid=ProteinBuffer,
             device="x_mantis",
             model="high_volume",
@@ -907,6 +909,8 @@ class TestLiquidHandleDispenseMode:
             source=self.tube.well(0),
             destination=self.flat.well(0),
             volume="5:uL",
+            rows=1,
+            columns=1,
             liquid=ProteinBuffer,
             device="x_mantis",
             model="low_volume",
@@ -934,7 +938,7 @@ class TestLiquidHandleDispenseMode:
 
     def test_mantis_bad_params(self):
         """Tests mantis bad params"""
-        # Incorrect model param
+        # Incorrect model param and incorrect liha shape
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(
                 source=self.tube.well(0),
@@ -955,6 +959,8 @@ class TestLiquidHandleDispenseMode:
                 source=self.tube.well(0),
                 destination=self.flat.well(0),
                 volume="5:uL",
+                rows=1,
+                columns=1,
                 liquid=ProteinBuffer,
                 device="x_mantis",
                 model="high_volume",
@@ -970,6 +976,8 @@ class TestLiquidHandleDispenseMode:
                     source=self.tube.well(0),
                     destination=self.flat.well(0),
                     volume="5:uL",
+                    rows=1,
+                    columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
                     model="high_volume",
@@ -985,6 +993,8 @@ class TestLiquidHandleDispenseMode:
                     source=self.tube.well(0),
                     destination=self.flat.well(0),
                     volume="5:uL",
+                    rows=1,
+                    columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
                     model="high_volume",
@@ -1000,6 +1010,8 @@ class TestLiquidHandleDispenseMode:
                     source=self.tube.well(0),
                     destination=self.flat.well(0),
                     volume="5:uL",
+                    rows=1,
+                    columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
                     model="high_volume",
@@ -1015,6 +1027,8 @@ class TestLiquidHandleDispenseMode:
                     source=self.tube.well(0),
                     destination=self.flat.well(0),
                     volume="5:uL",
+                    rows=1,
+                    columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
                     model="high_volume",

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -912,20 +912,14 @@ class TestLiquidHandleDispenseMode:
             device="x_mantis",
             model="low_volume",
             diaphragm=25,
-            nozzle_size="0.1:mm",
-            tubing="P200",
             z_drop="0.2:mm",
-            viscosity="1",
         )
 
         mode_params = {
             "x_mantis": {
                 "model": "low_volume",
                 "diaphragm": 25,
-                "nozzle_size": "0.1:mm",
-                "tubing": "P200",
                 "z_drop": "0.2:mm",
-                "viscosity": "1",
             }
         }
 
@@ -943,22 +937,12 @@ class TestLiquidHandleDispenseMode:
             columns=1,
             liquid=ProteinBuffer,
             device="x_mantis",
-            model="low_volume",
-            diaphragm=25,
-            nozzle_size="0.1:mm",
             tubing="pipette-tip-p200",
-            z_drop="0.2:mm",
-            viscosity="1",
         )
 
         mode_params = {
             "x_mantis": {
-                "model": "low_volume",
-                "diaphragm": 25,
-                "nozzle_size": "0.1:mm",
                 "tubing": "pipette-tip-p200",
-                "z_drop": "0.2:mm",
-                "viscosity": "1",
             }
         }
 
@@ -976,12 +960,6 @@ class TestLiquidHandleDispenseMode:
                 volume="5:uL",
                 liquid=ProteinBuffer,
                 device="x_mantis",
-                model="mid_volume",
-                diaphragm=0,
-                nozzle_size="0.1:mm",
-                tubing="LV",
-                z_drop="0.0:mm",
-                viscosity="1",
             )
         # Incorrect diaphragm value
         with pytest.raises(ValueError):
@@ -993,12 +971,7 @@ class TestLiquidHandleDispenseMode:
                 columns=1,
                 liquid=ProteinBuffer,
                 device="x_mantis",
-                model="high_volume",
                 diaphragm=101,
-                nozzle_size="0.1:mm",
-                tubing="LV",
-                z_drop="0.0:mm",
-                viscosity="1",
             )
             # Incorrect nozzle_size value
             with pytest.raises(ValueError):
@@ -1010,12 +983,7 @@ class TestLiquidHandleDispenseMode:
                     columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
-                    model="high_volume",
-                    diaphragm=101,
                     nozzle_size="0.3:mm",
-                    tubing="LV",
-                    z_drop="0.0:mm",
-                    viscosity="1",
                 )
             # Incorrect tubing value
             with pytest.raises(ValueError):
@@ -1027,12 +995,7 @@ class TestLiquidHandleDispenseMode:
                     columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
-                    model="high_volume",
-                    diaphragm=101,
-                    nozzle_size="0.3:mm",
                     tubing="MV",
-                    z_drop="0.0:mm",
-                    viscosity="1",
                 )
             # Incorrect z_drop value
             with pytest.raises(ValueError):
@@ -1044,12 +1007,7 @@ class TestLiquidHandleDispenseMode:
                     columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
-                    model="high_volume",
-                    diaphragm=101,
-                    nozzle_size="0.3:mm",
-                    tubing="LV",
                     z_drop="200.0:mm",
-                    viscosity="1",
                 )
             # Incorrect viscosity value
             with pytest.raises(ValueError):
@@ -1061,11 +1019,6 @@ class TestLiquidHandleDispenseMode:
                     columns=1,
                     liquid=ProteinBuffer,
                     device="x_mantis",
-                    model="high_volume",
-                    diaphragm=101,
-                    nozzle_size="0.3:mm",
-                    tubing="LV",
-                    z_drop="0.0:mm",
                     viscosity="100",
                 )
 

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -857,7 +857,7 @@ class TestLiquidHandleDispenseMode:
             )
 
     def test_mantis_default_params(self):
-        """ Tests mantis default params """
+        """Tests mantis default params"""
         instruction = self.protocol.liquid_handle_dispense(
             source=self.tube.well(0),
             destination=self.flat.well(0),
@@ -878,7 +878,7 @@ class TestLiquidHandleDispenseMode:
             nozzle_size="0.1:mm",
             tubing="LV",
             z_drop="0.0:mm",
-            viscosity="1"
+            viscosity="1",
         )
 
         mode_params = {
@@ -895,7 +895,7 @@ class TestLiquidHandleDispenseMode:
         assert instruction.data["mode_params"] == mode_params
 
     def test_mantis_other_params(self):
-        """ Tests mantis low_volume params, still accepted"""
+        """Tests mantis low_volume params, still accepted"""
         instruction = self.protocol.liquid_handle_dispense(
             source=self.tube.well(0),
             destination=self.flat.well(0),
@@ -907,7 +907,7 @@ class TestLiquidHandleDispenseMode:
             nozzle_size="0.1:mm",
             tubing="LV",
             z_drop="0.2:mm",
-            viscosity="1"
+            viscosity="1",
         )
 
         mode_params = {
@@ -924,7 +924,7 @@ class TestLiquidHandleDispenseMode:
         assert instruction.data["mode_params"] == mode_params
 
     def test_mantis_bad_params(self):
-        """ Tests mantis bad params """
+        """Tests mantis bad params"""
         # Incorrect model param
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(
@@ -938,7 +938,7 @@ class TestLiquidHandleDispenseMode:
                 nozzle_size="0.1:mm",
                 tubing="LV",
                 z_drop="0.0:mm",
-                viscosity="1"
+                viscosity="1",
             )
         # Incorrect diaphragm value
         with pytest.raises(ValueError):
@@ -953,7 +953,7 @@ class TestLiquidHandleDispenseMode:
                 nozzle_size="0.1:mm",
                 tubing="LV",
                 z_drop="0.0:mm",
-                viscosity="1"
+                viscosity="1",
             )
             # Incorrect nozzle_size value
             with pytest.raises(ValueError):
@@ -968,7 +968,7 @@ class TestLiquidHandleDispenseMode:
                     nozzle_size="0.3:mm",
                     tubing="LV",
                     z_drop="0.0:mm",
-                    viscosity="1"
+                    viscosity="1",
                 )
             # Incorrect tubing value
             with pytest.raises(ValueError):
@@ -983,7 +983,7 @@ class TestLiquidHandleDispenseMode:
                     nozzle_size="0.3:mm",
                     tubing="MV",
                     z_drop="0.0:mm",
-                    viscosity="1"
+                    viscosity="1",
                 )
             # Incorrect z_drop value
             with pytest.raises(ValueError):
@@ -998,7 +998,7 @@ class TestLiquidHandleDispenseMode:
                     nozzle_size="0.3:mm",
                     tubing="MV",
                     z_drop="200.0:mm",
-                    viscosity="1"
+                    viscosity="1",
                 )
             # Incorrect viscosity value
             with pytest.raises(ValueError):
@@ -1013,7 +1013,7 @@ class TestLiquidHandleDispenseMode:
                     nozzle_size="0.3:mm",
                     tubing="MV",
                     z_drop="0.0:mm",
-                    viscosity="100"
+                    viscosity="100",
                 )
 
     def test_liquid_handle_volume_tracking(self):

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -879,7 +879,7 @@ class TestLiquidHandleDispenseMode:
             device="x_mantis",
             model="high_volume",
             diaphragm=0,
-            nozzle_size="0.1:mm",
+            nozzle_size=Unit("0.1:mm"),
             tubing="LV",
             z_drop="0.0:mm",
             viscosity="1",
@@ -889,9 +889,9 @@ class TestLiquidHandleDispenseMode:
             "x_mantis": {
                 "model": "high_volume",
                 "diaphragm": 0,
-                "nozzle_size": "0.1:mm",
+                "nozzle_size": Unit("0.1:mm"),
                 "tubing": "LV",
-                "z_drop": "0.0:mm",
+                "z_drop": Unit("0.0:mm"),
                 "viscosity": "1",
             }
         }
@@ -919,7 +919,7 @@ class TestLiquidHandleDispenseMode:
             "x_mantis": {
                 "model": "low_volume",
                 "diaphragm": 25,
-                "z_drop": "0.2:mm",
+                "z_drop": Unit("0.2:mm"),
             }
         }
 

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -761,8 +761,6 @@ class TestLiquidHandleDispenseMode:
         mode_params = {
             "x_tempest_chip": {
                 "material": "silicone",
-                "nozzle": "standard",
-                "model": "high_volume",
             }
         }
 
@@ -775,15 +773,16 @@ class TestLiquidHandleDispenseMode:
             destination=self.flat.well(0),
             volume="5:uL",
             liquid=ProteinBuffer,
+            model="high_volume",
             chip_material="silicone",
             nozzle="standard",
         )
 
         mode_params = {
             "x_tempest_chip": {
+                "model": "high_volume",
                 "material": "silicone",
                 "nozzle": "standard",
-                "model": "high_volume",
             }
         }
 
@@ -802,8 +801,6 @@ class TestLiquidHandleDispenseMode:
         mode_params = {
             "x_tempest_chip": {
                 "material": "pfe",
-                "nozzle": "standard",
-                "model": "high_volume",
             }
         }
 

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -1026,17 +1026,17 @@ class TestMantisDispenseMode:
                 diaphragm=101,
             )
         # Incorrect nozzle_size value
-        with pytest.raises(ValueError):
-            self.protocol.liquid_handle_dispense(
-                source=self.tube.well(0),
-                destination=self.flat.well(0),
-                volume="5:uL",
-                rows=1,
-                columns=1,
-                liquid=ProteinBuffer,
-                device="x_mantis",
-                nozzle_size="0.3:mm",
-            )
+        # with pytest.raises(ValueError):
+        #     self.protocol.liquid_handle_dispense(
+        #         source=self.tube.well(0),
+        #         destination=self.flat.well(0),
+        #         volume="5:uL",
+        #         rows=1,
+        #         columns=1,
+        #         liquid=ProteinBuffer,
+        #         device="x_mantis",
+        #         nozzle_size="0.3:mm",
+        #     )
         # Incorrect tubing value
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -967,29 +967,6 @@ class TestMantisDispenseMode:
         assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
         assert instruction.data["mode_params"] == mode_params
 
-    def test_p200_shortname_params(self):
-        """Tests that pipette-tip-p200 is still accepted"""
-        instruction = self.protocol.liquid_handle_dispense(
-            source=self.tube.well(0),
-            destination=self.flat.well(0),
-            volume="5:uL",
-            rows=1,
-            columns=1,
-            liquid=ProteinBuffer,
-            device="x_mantis",
-            tubing="pipette-tip-p200",
-        )
-
-        mode_params = {
-            "x_mantis": {
-                "tubing": "pipette-tip-p200",
-            }
-        }
-
-        liha_shape = instruction.data["shape"]
-        assert liha_shape["rows"] == 1 and liha_shape["columns"] == 1
-        assert instruction.data["mode_params"] == mode_params
-
     def test_mantis_bad_params(self):
         """Tests mantis bad params"""
         # Passing in tempest-specific param

--- a/test/liquid_handle_dispense_test.py
+++ b/test/liquid_handle_dispense_test.py
@@ -952,6 +952,18 @@ class TestLiquidHandleDispenseMode:
 
     def test_mantis_bad_params(self):
         """Tests mantis bad params"""
+        # Passing in tempest-specific param
+        with pytest.raises(KeyError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                nozzle="standard",
+            )
         # Incorrect model param and incorrect liha shape for mantis
         with pytest.raises(ValueError):
             self.protocol.liquid_handle_dispense(
@@ -973,54 +985,54 @@ class TestLiquidHandleDispenseMode:
                 device="x_mantis",
                 diaphragm=101,
             )
-            # Incorrect nozzle_size value
-            with pytest.raises(ValueError):
-                self.protocol.liquid_handle_dispense(
-                    source=self.tube.well(0),
-                    destination=self.flat.well(0),
-                    volume="5:uL",
-                    rows=1,
-                    columns=1,
-                    liquid=ProteinBuffer,
-                    device="x_mantis",
-                    nozzle_size="0.3:mm",
-                )
-            # Incorrect tubing value
-            with pytest.raises(ValueError):
-                self.protocol.liquid_handle_dispense(
-                    source=self.tube.well(0),
-                    destination=self.flat.well(0),
-                    volume="5:uL",
-                    rows=1,
-                    columns=1,
-                    liquid=ProteinBuffer,
-                    device="x_mantis",
-                    tubing="MV",
-                )
-            # Incorrect z_drop value
-            with pytest.raises(ValueError):
-                self.protocol.liquid_handle_dispense(
-                    source=self.tube.well(0),
-                    destination=self.flat.well(0),
-                    volume="5:uL",
-                    rows=1,
-                    columns=1,
-                    liquid=ProteinBuffer,
-                    device="x_mantis",
-                    z_drop="200.0:mm",
-                )
-            # Incorrect viscosity value
-            with pytest.raises(ValueError):
-                self.protocol.liquid_handle_dispense(
-                    source=self.tube.well(0),
-                    destination=self.flat.well(0),
-                    volume="5:uL",
-                    rows=1,
-                    columns=1,
-                    liquid=ProteinBuffer,
-                    device="x_mantis",
-                    viscosity="100",
-                )
+        # Incorrect nozzle_size value
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                nozzle_size="0.3:mm",
+            )
+        # Incorrect tubing value
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                tubing="MV",
+            )
+        # Incorrect z_drop value
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                z_drop="200.0:mm",
+            )
+        # Incorrect viscosity value
+        with pytest.raises(ValueError):
+            self.protocol.liquid_handle_dispense(
+                source=self.tube.well(0),
+                destination=self.flat.well(0),
+                volume="5:uL",
+                rows=1,
+                columns=1,
+                liquid=ProteinBuffer,
+                device="x_mantis",
+                viscosity="100",
+            )
 
     def test_liquid_handle_volume_tracking(self):
         self.tube.well(0).set_volume("0:microliter")

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -4,7 +4,11 @@ from autoprotocol.container_type import _CONTAINER_TYPES
 from autoprotocol.instruction import LiquidHandle
 from autoprotocol.protocol import Protocol
 from autoprotocol.unit import Unit
-from autoprotocol.util import _check_container_type_with_shape, parse_unit
+from autoprotocol.util import (
+    _check_container_type_with_shape,
+    parse_unit,
+    _validate_liha_shape,
+)
 
 
 class TestParseUnit(object):
@@ -31,6 +35,16 @@ class TestParseUnit(object):
 
 
 class TestUtil(object):
+    def test_liha_validation(self):
+        # asserts that no exception is raised if liha params are valid.
+        # Otherwise, raises ValueError
+        try:
+            _validate_liha_shape("x_mantis", {"rows": 1, "columns": 1})
+        except Exception as exc:
+            assert False, f"{exc}"
+        with pytest.raises(ValueError):
+            _validate_liha_shape("x_mantis", {"rows": 2, "columns": 1})
+
     def test_compatible_reservoir_container(self):
         # asserts that no exception is raised. If it raises an exception, we catch it, display it, and assert False.
         try:

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -40,7 +40,7 @@ class TestUtil(object):
         # Otherwise, raises ValueError
         try:
             _validate_liha_shape("x_mantis", {"rows": 1, "columns": 1})
-        except Exception as exc: # pylint: disable=W0703
+        except Exception as exc:  # pylint: disable=W0703
             assert False, f"{exc}"
         with pytest.raises(ValueError):
             _validate_liha_shape("x_mantis", {"rows": 2, "columns": 1})

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -6,8 +6,8 @@ from autoprotocol.protocol import Protocol
 from autoprotocol.unit import Unit
 from autoprotocol.util import (
     _check_container_type_with_shape,
-    parse_unit,
     _validate_liha_shape,
+    parse_unit,
 )
 
 

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -40,7 +40,7 @@ class TestUtil(object):
         # Otherwise, raises ValueError
         try:
             _validate_liha_shape("x_mantis", {"rows": 1, "columns": 1})
-        except Exception as exc:
+        except Exception as exc: # pylint: disable=W0703
             assert False, f"{exc}"
         with pytest.raises(ValueError):
             _validate_liha_shape("x_mantis", {"rows": 2, "columns": 1})


### PR DESCRIPTION
[SCIENG-223](https://strateos.atlassian.net/browse/SCIENG-223)

Started new branch, but from `master`

[SCIENG-223]: https://strateos.atlassian.net/browse/SCIENG-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

referencing [#1109](https://github.com/strateos/internal_protocols/pull/1109)

## Test Plan
### Test New Txappy
Release `txappy` and then:
- [x] add a new test that uses a tip type as a source
- [x] [submit to WEB](https://webapp.staging.strateos.com/transcriptic/p1ax2tm4re3b9pezp/runs/r1ax569wg75kvj2v8/instructions)


Testing Mantis Driver Task will cover following tests
### Should pass
- [ ] [Test `device_mode_params` 3 different levels of param specification](https://webapp.staging.strateos.com/transcriptic/runspage/queue/accepted/runs/r1ax35hdyp5yjh3ru/prime)`
- [ ] [Test `dispense` to full 96-plate](https://webapp.staging.strateos.com/transcriptic/runspage/queue/accepted/runs/r1ax36ujrgrmjdrxb/prime)
- [ ] [Test `dispense` from many sources to 1 destination _over several instructions_](https://webapp.staging.strateos.com/transcriptic/runspage/queue/accepted/runs/r1ax372yjeysb2fyp/prime)
### Should fail
- [ ] [Test `dispense` from 1 source to 2+ destination plates](https://webapp.staging.strateos.com/transcriptic/runspage/queue/accepted/runs/r1ax37adavd7uc9em/prime)
- [ ] [Test `dispense` from many source to 1 destination](https://webapp.staging.strateos.com/transcriptic/runspage/queue/accepted/runs/r1ax376fzjgzvvp8k/prime)