### PR TITLE
PP-12831

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -7896,7 +7896,7 @@ class Protocol:
 
         # apply tip types to transfer methods
         for vol, met in zip(volume, method):
-            if not met.tip_type:
+            if met._has_calibration() and not met.tip_type:
                 try:
                     # met.tip_type = met._rec_tip_type(vol)
                     met._rec_tip_type(vol)

--- a/autoprotocol/version.py
+++ b/autoprotocol/version.py
@@ -1,2 +1,2 @@
 """Maintains current version of package"""
-__version__ = "10.2.3"
+__version__ = "10.2.4"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,9 @@
 =========
 Changelog
 =========
+* :release: `10.2.4 <2023-04-18>`
+* :bug:`395` Refactor tip types to transfer methods
+
 
 * :release: `10.2.3 <2023-04-03>`
 * :bug:`391` Revert rec_tip_type implementation


### PR DESCRIPTION
This PR updates protocol.py to not pass in mode params and tip type in the liquid handle transfer instruction. 

Tested by generating a[ test run](https://secure.strateos.com/strateos_sd_qc/p1gxgkdddyg6sz/runs/r1axj4ca7qj9b462g/instructions) and you can see the last two liquid handle instructions dont have the mode params and tip type appended. 