### PR TITLE
Fix OligosynthesizeOligo serialization

### DIFF
--- a/autoprotocol/protocol.py
+++ b/autoprotocol/protocol.py
@@ -10,7 +10,7 @@ import json
 import warnings
 
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from numbers import Number
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -4197,7 +4197,6 @@ class Protocol:
 
         instructions = []
         for pe in parsed_extracts:
-
             lane_set = [e["lane"] for e in pe]
 
             if len(lane_set) > max_well:
@@ -5090,7 +5089,7 @@ class Protocol:
                         if c.get("emission_wavelength"):
                             try:
                                 Unit(c.get("emission_wavelength"))
-                            except (UnitError) as e:
+                            except UnitError as e:
                                 raise UnitError(
                                     "Each `emission_wavelength` "
                                     "must be of type unit."
@@ -5102,7 +5101,7 @@ class Protocol:
                         if c.get("excitation_wavelength"):
                             try:
                                 Unit(c.get("excitation_wavelength"))
-                            except (UnitError) as e:
+                            except UnitError as e:
                                 raise UnitError(
                                     "Each `excitation_wavelength` "
                                     "must be of type unit."
@@ -5717,7 +5716,6 @@ class Protocol:
         return self._add_mag(mag, head, new_tip, new_instruction, "mix")
 
     def image_plate(self, ref: Union[str, Container], mode: str, dataref: str):
-
         """
         Capture an image of the specified container.
 
@@ -6594,6 +6592,7 @@ class Protocol:
             Ref,
             Compound,
             Informatics,
+            OligosynthesizeOligo,
         ],
     ):
         """
@@ -6631,6 +6630,10 @@ class Protocol:
             return op_data.as_dict()
         elif isinstance(op_data, Informatics):
             return self._refify(op_data.as_dict())
+        elif isinstance(op_data, OligosynthesizeOligo):
+            return self._refify(
+                {field.name: getattr(op_data, field.name) for field in fields(op_data)}
+            )
         else:
             return op_data
 


### PR DESCRIPTION
Example given in documentation for protocol.oligosynthesize does not work because OligosynthesizeOligo objects do not get properly serialized by protocol.as_dict() method:

```
Python 3.11.4 | packaged by conda-forge | (main, Jun 10 2023, 18:10:28) [Clang 15.0.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from autoprotocol.protocol import Protocol
>>> import json
>>> p = Protocol()
>>> oligo_1 = p.ref("oligo_1", None, "micro-1.5", discard=True)
>>> 
>>> p.oligosynthesize([{"sequence": "CATGGTCCCCTGCACAGG",
...                     "destination": oligo_1.well(0),
...                     "scale": "25nm",
...                     "purification": "standard"}])
Instruction(oligosynthesize, {'oligos': [OligosynthesizeOligo(destination=Well(Container(oligo_1), 0, None), sequence='CATGGTCCCCTGCACAGG', scale='25nm', purification='standard')]}, [])
>>> print(json.dumps(p.as_dict(), indent=2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 202, in encode
    chunks = list(chunks)
             ^^^^^^^^^^^^
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 432, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
    yield from chunks
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 326, in _iterencode_list
    yield from chunks
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
    yield from chunks
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 326, in _iterencode_list
    yield from chunks
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 439, in _iterencode
    o = _default(o)
        ^^^^^^^^^^^
  File "/Users/albertonava/mambaforge/envs/dnada11/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type OligosynthesizeOligo is not JSON serializable
>>> print(p.as_dict())
{'instructions': [{'op': 'oligosynthesize', 'oligos': [OligosynthesizeOligo(destination=Well(Container(oligo_1), 0, None), sequence='CATGGTCCCCTGCACAGG', scale='25nm', purification='standard')]}], 'refs': {'oligo_1': {'new': 'micro-1.5', 'discard': True}}}
```

Python Version: 3.11.4
Autoprotocol-python Version: 10.3.0

This pull request fixes this bug. There are a few other additional line changes from black formatting. 